### PR TITLE
Fix: "Directory not empty" when creating a new project

### DIFF
--- a/blogr-cli/src/project.rs
+++ b/blogr-cli/src/project.rs
@@ -55,7 +55,7 @@ impl Project {
         github_username: Option<String>,
         github_repo: Option<String>,
     ) -> Result<Self> {
-        let project_path = path.as_ref().to_path_buf();
+        let project_path = path.as_ref().to_path_buf().join(&name);
 
         // Create project directory if it doesn't exist
         if !project_path.exists() {


### PR DESCRIPTION
__PROBLEM__
- #11 

__INVESTIGATION__
`Project::init` is given a path that in all cases (`handle_init`, `interactive_init`) is just the current directory from `std::env::current_dir()`. Then it checks to see if the directory exists. At first I had thought maybe the app is working as intended (create dir before running `init`) but after seeing this I decided to go ahead with with this PR.

__SOLUTION__
Join the project name to the base path at the start of `Project::init`

__TESTING__
- automated tests pass
- #11 steps now succeed
- README quickstart steps now succeed