### PR TITLE
Fix & refactor config menu selection logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "strum 0.27.2",
  "syntect",
  "tempfile",
  "tera",
@@ -2260,7 +2261,7 @@ dependencies = [
  "itertools",
  "lru",
  "paste",
- "strum",
+ "strum 0.25.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -2806,7 +2807,16 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2819,6 +2829,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.106",
 ]
 

--- a/blogr-cli/Cargo.toml
+++ b/blogr-cli/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 open = "5.0"
 urlencoding = "2.1"
+strum = { version = "0.27.2", features = ["derive"] }
 
 # Newsletter dependencies
 imap = "2.3.0"

--- a/blogr-cli/src/tui/config_app.rs
+++ b/blogr-cli/src/tui/config_app.rs
@@ -4,17 +4,46 @@ use crate::tui::theme::TuiTheme;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
     Frame,
 };
-use strum::{EnumIter, IntoEnumIterator};
+use strum::{EnumIter, IntoEnumIterator, VariantArray};
 
 pub type AppResult<T> = anyhow::Result<T>;
 
+#[derive(PartialEq, Eq)]
+enum HighLevelListItem {
+    Field(ConfigField),
+    Section(ConfigFieldSection),
+    BlankLine,
+}
+
+fn create_high_level_list_items() -> Vec<HighLevelListItem> {
+    ConfigFieldSection::iter()
+        .map(|section| (section, section.get_fields()))
+        .map(|(section, fields)| {
+            let mut list_section = vec![
+                HighLevelListItem::BlankLine,
+                HighLevelListItem::Section(section),
+            ];
+            list_section.append(
+                &mut fields
+                    .iter()
+                    .map(|field| HighLevelListItem::Field(*field))
+                    .collect(),
+            );
+            list_section
+        })
+        .fold(Vec::new(), |mut acc, mut list_section| {
+            acc.append(&mut list_section);
+            acc
+        })
+}
+
 /// Configuration field types
-#[derive(Debug, Clone, EnumIter)]
+#[derive(Debug, Clone, Copy, EnumIter, VariantArray, PartialEq, Eq)]
 pub enum ConfigField {
     BlogTitle,
     BlogAuthor,
@@ -175,10 +204,10 @@ pub struct ConfigApp {
     pub project: Project,
     /// Current theme
     pub theme: TuiTheme,
-    /// Available configuration fields
-    pub fields: Vec<ConfigField>,
     /// Current field selection
-    pub selected_field: usize,
+    pub selected_field: ConfigField,
+    pub config_index: usize,
+    list_items: Vec<HighLevelListItem>,
     /// List state for field selection
     pub list_state: ListState,
     /// Current edit buffer
@@ -194,19 +223,18 @@ pub struct ConfigApp {
 impl ConfigApp {
     /// Create a new configuration app
     pub fn new(config: Config, project: Project, theme: TuiTheme) -> Self {
-        let fields = ConfigField::iter().collect();
-
         let mut list_state = ListState::default();
-        list_state.select(Some(0));
-
+        list_state.select(Some(2));
+        let list_items = create_high_level_list_items();
         Self {
             running: true,
             mode: ConfigMode::Browse,
             config,
             project,
             theme,
-            fields,
-            selected_field: 0,
+            selected_field: ConfigField::BlogTitle,
+            config_index: 0,
+            list_items,
             list_state,
             edit_buffer: String::new(),
             status_message: "Navigate with ↑/↓, Enter to edit, 'q' to quit, 's' to save"
@@ -247,15 +275,30 @@ impl ConfigApp {
                 self.mode = ConfigMode::Help;
             }
             KeyCode::Up => {
-                if self.selected_field > 0 {
-                    self.selected_field -= 1;
-                    self.list_state.select(Some(self.selected_field));
+                if self.config_index == 0 {
+                    return Ok(());
+                }
+                let prev = ConfigField::VARIANTS.get(self.config_index - 1);
+                if let Some(prev) = prev {
+                    self.selected_field = *prev;
+                    self.config_index -= 1;
+                    let index = self.list_items.iter().position(|item| match item {
+                        HighLevelListItem::Field(field) => field == prev,
+                        _ => false,
+                    });
+                    self.list_state.select(index);
                 }
             }
             KeyCode::Down => {
-                if self.selected_field < self.fields.len() - 1 {
-                    self.selected_field += 1;
-                    self.list_state.select(Some(self.selected_field));
+                let next = ConfigField::VARIANTS.get(self.config_index + 1);
+                if let Some(next) = next {
+                    self.selected_field = *next;
+                    self.config_index += 1;
+                    let index = self.list_items.iter().position(|item| match item {
+                        HighLevelListItem::Field(field) => field == next,
+                        _ => false,
+                    });
+                    self.list_state.select(index);
                 }
             }
             KeyCode::Enter => {
@@ -307,125 +350,122 @@ impl ConfigApp {
     }
 
     fn enter_edit_mode(&mut self) {
-        if let Some(field) = self.fields.get(self.selected_field) {
-            self.edit_buffer = field.get_value(&self.config);
-            self.mode = ConfigMode::Edit;
-            self.status_message = format!("Editing {}: Press Enter to save, Esc to cancel", field);
-        }
+        self.edit_buffer = self.selected_field.get_value(&self.config);
+        self.mode = ConfigMode::Edit;
+        self.status_message = format!(
+            "Editing {}: Press Enter to save, Esc to cancel",
+            self.selected_field
+        );
     }
 
     fn apply_edit(&mut self) -> AppResult<()> {
-        if let Some(field) = self.fields.get(self.selected_field) {
-            let value = self.edit_buffer.trim().to_string();
+        let value = self.edit_buffer.trim().to_string();
 
-            // Apply the change to the configuration
-            match field {
-                ConfigField::BlogTitle => {
-                    if !value.is_empty() {
-                        self.config.blog.title = value;
-                        self.modified = true;
-                    }
-                }
-                ConfigField::BlogAuthor => {
-                    if !value.is_empty() {
-                        self.config.blog.author = value;
-                        self.modified = true;
-                    }
-                }
-                ConfigField::BlogDescription => {
-                    if !value.is_empty() {
-                        self.config.blog.description = value;
-                        self.modified = true;
-                    }
-                }
-                ConfigField::BlogBaseUrl => {
-                    if !value.is_empty() {
-                        self.config.blog.base_url = value;
-                        self.modified = true;
-                    }
-                }
-                ConfigField::BlogLanguage => {
-                    self.config.blog.language = if value.is_empty() { None } else { Some(value) };
-                    self.modified = true;
-                }
-                ConfigField::BlogTimezone => {
-                    self.config.blog.timezone = if value.is_empty() { None } else { Some(value) };
-                    self.modified = true;
-                }
-                ConfigField::ThemeName => {
-                    if !value.is_empty() {
-                        self.config.theme.name = value;
-                        self.modified = true;
-                    }
-                }
-                ConfigField::DomainPrimary => {
-                    if self.config.blog.domains.is_none() {
-                        self.config.blog.domains = Some(crate::config::DomainConfig {
-                            primary: None,
-                            aliases: Vec::new(),
-                            subdomain: None,
-                            enforce_https: true,
-                            github_pages_domain: None,
-                        });
-                    }
-                    if let Some(domains) = &mut self.config.blog.domains {
-                        domains.primary = if value.is_empty() {
-                            None
-                        } else {
-                            Some(value.clone())
-                        };
-                        domains.github_pages_domain =
-                            if value.is_empty() { None } else { Some(value) };
-                        self.modified = true;
-                    }
-                }
-                ConfigField::DomainEnforceHttps => {
-                    let enforce_https = value.to_lowercase() == "true";
-                    if self.config.blog.domains.is_none() {
-                        self.config.blog.domains = Some(crate::config::DomainConfig {
-                            primary: None,
-                            aliases: Vec::new(),
-                            subdomain: None,
-                            enforce_https,
-                            github_pages_domain: None,
-                        });
-                    }
-                    if let Some(domains) = &mut self.config.blog.domains {
-                        domains.enforce_https = enforce_https;
-                        self.modified = true;
-                    }
-                }
-                ConfigField::BuildOutputDir => {
-                    self.config.build.output_dir =
-                        if value.is_empty() { None } else { Some(value) };
-                    self.modified = true;
-                }
-                ConfigField::BuildDrafts => {
-                    self.config.build.drafts = value.to_lowercase() == "true";
-                    self.modified = true;
-                }
-                ConfigField::BuildFuturePosts => {
-                    self.config.build.future_posts = value.to_lowercase() == "true";
-                    self.modified = true;
-                }
-                ConfigField::DevPort => {
-                    if let Ok(port) = value.parse::<u16>() {
-                        if port > 0 {
-                            self.config.dev.port = port;
-                            self.modified = true;
-                        }
-                    }
-                }
-                ConfigField::DevAutoReload => {
-                    self.config.dev.auto_reload = value.to_lowercase() == "true";
+        // Apply the change to the configuration
+        match self.selected_field {
+            ConfigField::BlogTitle => {
+                if !value.is_empty() {
+                    self.config.blog.title = value;
                     self.modified = true;
                 }
             }
-
-            self.mode = ConfigMode::Browse;
-            self.edit_buffer.clear();
-            self.status_message = format!("{} updated", field);
+            ConfigField::BlogAuthor => {
+                if !value.is_empty() {
+                    self.config.blog.author = value;
+                    self.modified = true;
+                }
+            }
+            ConfigField::BlogDescription => {
+                if !value.is_empty() {
+                    self.config.blog.description = value;
+                    self.modified = true;
+                }
+            }
+            ConfigField::BlogBaseUrl => {
+                if !value.is_empty() {
+                    self.config.blog.base_url = value;
+                    self.modified = true;
+                }
+            }
+            ConfigField::BlogLanguage => {
+                self.config.blog.language = if value.is_empty() { None } else { Some(value) };
+                self.modified = true;
+            }
+            ConfigField::BlogTimezone => {
+                self.config.blog.timezone = if value.is_empty() { None } else { Some(value) };
+                self.modified = true;
+            }
+            ConfigField::ThemeName => {
+                if !value.is_empty() {
+                    self.config.theme.name = value;
+                    self.modified = true;
+                }
+            }
+            ConfigField::DomainPrimary => {
+                if self.config.blog.domains.is_none() {
+                    self.config.blog.domains = Some(crate::config::DomainConfig {
+                        primary: None,
+                        aliases: Vec::new(),
+                        subdomain: None,
+                        enforce_https: true,
+                        github_pages_domain: None,
+                    });
+                }
+                if let Some(domains) = &mut self.config.blog.domains {
+                    domains.primary = if value.is_empty() {
+                        None
+                    } else {
+                        Some(value.clone())
+                    };
+                    domains.github_pages_domain = if value.is_empty() { None } else { Some(value) };
+                    self.modified = true;
+                }
+            }
+            ConfigField::DomainEnforceHttps => {
+                let enforce_https = value.to_lowercase() == "true";
+                if self.config.blog.domains.is_none() {
+                    self.config.blog.domains = Some(crate::config::DomainConfig {
+                        primary: None,
+                        aliases: Vec::new(),
+                        subdomain: None,
+                        enforce_https,
+                        github_pages_domain: None,
+                    });
+                }
+                if let Some(domains) = &mut self.config.blog.domains {
+                    domains.enforce_https = enforce_https;
+                    self.modified = true;
+                }
+            }
+            ConfigField::BuildOutputDir => {
+                self.config.build.output_dir = if value.is_empty() { None } else { Some(value) };
+                self.modified = true;
+            }
+            ConfigField::BuildDrafts => {
+                self.config.build.drafts = value.to_lowercase() == "true";
+                self.modified = true;
+            }
+            ConfigField::BuildFuturePosts => {
+                self.config.build.future_posts = value.to_lowercase() == "true";
+                self.modified = true;
+            }
+            ConfigField::DevPort => {
+                if let Ok(port) = value.parse::<u16>() {
+                    if port > 0 {
+                        self.config.dev.port = port;
+                        self.modified = true;
+                    }
+                }
+            }
+            ConfigField::DevAutoReload => {
+                self.config.dev.auto_reload = value.to_lowercase() == "true";
+                self.modified = true;
+            }
         }
+
+        self.mode = ConfigMode::Browse;
+        self.edit_buffer.clear();
+        self.status_message = format!("{} updated", self.selected_field);
         Ok(())
     }
 
@@ -499,23 +539,12 @@ impl ConfigApp {
     }
 
     fn render_field_list(&mut self, frame: &mut Frame, area: Rect) {
-        let sections_with_fields = ConfigFieldSection::iter()
-            .map(|section| (section, section.get_fields()))
-            .collect::<Vec<(ConfigFieldSection, Vec<ConfigField>)>>();
-
-        let mut items = Vec::new();
-
-        for (section, fields) in sections_with_fields {
-            items.push(ListItem::new(""));
-            items.push(ListItem::new(Line::from(Span::styled(
-                section.to_string(),
-                Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .fg(self.theme.primary_color),
-            ))));
-            let mut field_lines = fields
-                .iter()
-                .map(|field| {
+        let items = self
+            .list_items
+            .iter()
+            .map(|item| match item {
+                HighLevelListItem::BlankLine => ListItem::new(""),
+                HighLevelListItem::Field(field) => {
                     let value = field.get_value(&self.config);
                     let display_value = if value.len() > 20 {
                         format!("{}...", &value[..17])
@@ -527,12 +556,17 @@ impl ConfigApp {
                             format!("  {}: ", field),
                             Style::default().fg(self.theme.text_color),
                         ),
-                        Span::styled(display_value, Style::default().fg(Color::Gray)),
+                        Span::styled(display_value, Style::default().fg(self.theme.text_color)),
                     ]))
-                })
-                .collect::<Vec<ListItem>>();
-            items.append(&mut field_lines);
-        }
+                }
+                HighLevelListItem::Section(section) => ListItem::new(Line::from(Span::styled(
+                    section.to_string(),
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(self.theme.primary_color),
+                ))),
+            })
+            .collect::<Vec<ListItem>>();
 
         let list = List::new(items)
             .block(
@@ -551,85 +585,81 @@ impl ConfigApp {
     }
 
     fn render_field_details(&self, frame: &mut Frame, area: Rect) {
-        if let Some(field) = self.fields.get(self.selected_field) {
-            let value = field.get_value(&self.config);
-            let effective_url = if matches!(field, ConfigField::BlogBaseUrl) {
-                format!("\nEffective URL: {}", self.config.get_effective_base_url())
-            } else {
-                String::new()
-            };
+        let value = self.selected_field.get_value(&self.config);
+        let effective_url = if matches!(self.selected_field, ConfigField::BlogBaseUrl) {
+            format!("\nEffective URL: {}", self.config.get_effective_base_url())
+        } else {
+            String::new()
+        };
 
-            let content = format!(
-                "Field: {}\nCategory: {}\nCurrent Value: {}{}\n\nPress Enter to edit this field",
-                field,
-                field.category(),
-                value,
-                effective_url
-            );
+        let content = format!(
+            "Field: {}\nCategory: {}\nCurrent Value: {}{}\n\nPress Enter to edit this field",
+            self.selected_field,
+            self.selected_field.category(),
+            value,
+            effective_url
+        );
 
-            let details = Paragraph::new(content)
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .title("Field Details")
-                        .border_style(self.theme.border_style()),
-                )
-                .wrap(Wrap { trim: true })
-                .style(self.theme.text_style());
-
-            frame.render_widget(details, area);
-        }
-    }
-
-    fn render_edit_mode(&self, frame: &mut Frame, area: Rect) {
-        if let Some(field) = self.fields.get(self.selected_field) {
-            let edit_area = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Length(5), Constraint::Min(0)])
-                .split(area);
-
-            let input_text = if field.is_boolean() {
-                format!("{} (true/false)", self.edit_buffer)
-            } else if field.is_numeric() {
-                format!("{} (number)", self.edit_buffer)
-            } else {
-                self.edit_buffer.clone()
-            };
-
-            let input = Paragraph::new(input_text)
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .title(format!("Editing: {}", field))
-                        .border_style(self.theme.focused_border_style()),
-                )
-                .style(self.theme.text_style());
-
-            frame.render_widget(input, edit_area[0]);
-
-            let help_text = if field.is_boolean() {
-                "Enter 'true' or 'false'"
-            } else if field.is_numeric() {
-                "Enter a valid number"
-            } else {
-                "Enter the new value"
-            };
-
-            let help = Paragraph::new(format!(
-                "{}\n\nPress Enter to save, Esc to cancel",
-                help_text
-            ))
+        let details = Paragraph::new(content)
             .block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .title("Help")
+                    .title("Field Details")
                     .border_style(self.theme.border_style()),
             )
             .wrap(Wrap { trim: true })
             .style(self.theme.text_style());
 
-            frame.render_widget(help, edit_area[1]);
-        }
+        frame.render_widget(details, area);
+    }
+
+    fn render_edit_mode(&self, frame: &mut Frame, area: Rect) {
+        let edit_area = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(5), Constraint::Min(0)])
+            .split(area);
+
+        let input_text = if self.selected_field.is_boolean() {
+            format!("{} (true/false)", self.edit_buffer)
+        } else if self.selected_field.is_numeric() {
+            format!("{} (number)", self.edit_buffer)
+        } else {
+            self.edit_buffer.clone()
+        };
+
+        let input = Paragraph::new(input_text)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!("Editing: {}", self.selected_field))
+                    .border_style(self.theme.focused_border_style()),
+            )
+            .style(self.theme.text_style());
+
+        frame.render_widget(input, edit_area[0]);
+
+        let help_text = if self.selected_field.is_boolean() {
+            "Enter 'true' or 'false'"
+        } else if self.selected_field.is_numeric() {
+            "Enter a valid number"
+        } else {
+            "Enter the new value"
+        };
+
+        let help = Paragraph::new(format!(
+            "{}\n\nPress Enter to save, Esc to cancel",
+            help_text
+        ))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Help")
+                .border_style(self.theme.border_style()),
+        )
+        .wrap(Wrap { trim: true })
+        .style(self.theme.text_style());
+
+        frame.render_widget(help, edit_area[1]);
     }
 
     fn render_status_bar(&self, frame: &mut Frame, area: Rect) {

--- a/blogr-cli/src/tui/config_app.rs
+++ b/blogr-cli/src/tui/config_app.rs
@@ -16,14 +16,14 @@ pub type AppResult<T> = anyhow::Result<T>;
 #[derive(PartialEq, Eq)]
 enum HighLevelListItem {
     Field(ConfigField),
-    Section(ConfigFieldSection),
+    Section(ConfigSection),
     BlankLine,
 }
 
 struct HighLevelConfigList(Vec<HighLevelListItem>);
 impl HighLevelConfigList {
     fn new() -> Self {
-        let inner = ConfigFieldSection::iter()
+        let inner = ConfigSection::iter()
             .map(|section| (section, section.get_fields()))
             .map(|(section, fields)| {
                 let mut list_section = vec![
@@ -96,20 +96,20 @@ impl std::fmt::Display for ConfigField {
 }
 
 impl ConfigField {
-    pub fn category(&self) -> ConfigFieldSection {
+    pub fn category(&self) -> ConfigSection {
         match self {
             Self::BlogTitle
             | Self::BlogAuthor
             | Self::BlogDescription
             | Self::BlogBaseUrl
             | Self::BlogLanguage
-            | Self::BlogTimezone => ConfigFieldSection::Blog,
-            Self::ThemeName => ConfigFieldSection::Theme,
-            Self::DomainPrimary | ConfigField::DomainEnforceHttps => ConfigFieldSection::Domain,
+            | Self::BlogTimezone => ConfigSection::Blog,
+            Self::ThemeName => ConfigSection::Theme,
+            Self::DomainPrimary | ConfigField::DomainEnforceHttps => ConfigSection::Domain,
             Self::BuildOutputDir | Self::BuildDrafts | Self::BuildFuturePosts => {
-                ConfigFieldSection::Build
+                ConfigSection::Build
             }
-            Self::DevPort | ConfigField::DevAutoReload => ConfigFieldSection::Development,
+            Self::DevPort | ConfigField::DevAutoReload => ConfigSection::Development,
         }
     }
 
@@ -165,7 +165,7 @@ impl ConfigField {
 }
 
 #[derive(Debug, Clone, Copy, EnumIter, PartialEq, Eq, Hash)]
-pub enum ConfigFieldSection {
+pub enum ConfigSection {
     Blog,
     Theme,
     Domain,
@@ -173,7 +173,7 @@ pub enum ConfigFieldSection {
     Development,
 }
 
-impl std::fmt::Display for ConfigFieldSection {
+impl std::fmt::Display for ConfigSection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
             Self::Blog => "Blog Settings",
@@ -186,7 +186,7 @@ impl std::fmt::Display for ConfigFieldSection {
     }
 }
 
-impl ConfigFieldSection {
+impl ConfigSection {
     fn get_fields(&self) -> Vec<ConfigField> {
         ConfigField::iter()
             .filter(|field| field.category() == *self)


### PR DESCRIPTION
__PROBLEM__
Fixes #7. the issue notes that the visually selected menu item doesn't correspond to what's actually selected. Sometimes it's off by one, sometimes off by several, depending on where in the list you are, with the difference increasing as you descend.

__INVESTIGATION__
Because it's not offset by a fixed number, there isn't a super simple fix possible without creating some kind of higher level abstraction of the list layout that allows us to consider the logical layout and physical layout of the list separately and map between the two.

__SOLUTION__
We can use enums to make invalid list selection states unrepresentable, so blank lines and headers are skipped over by the cursor and we don't have to check whether or not a config field is selected when entering edit mode - one always is. `HighLevelListLayout` is a type that represents the list composed of blank lines, headers, and config fields. Using `strum` allows us to access our `ConfigField` as a const array and an iterator and use our position in that array to define selection. We do still have to map to the real 'physical' layout of the list to give ratatui the list index to highlight. `HighLevelListLayout` does this for us by finding the list layout position of the currently selected field.

https://github.com/user-attachments/assets/fd5617a7-0768-4704-895b-223004f3dd3f

