### PR TITLE
feat: allow content.md theme_config to override blogr.toml

### DIFF
--- a/blogr-cli/src/generator/site.rs
+++ b/blogr-cli/src/generator/site.rs
@@ -429,6 +429,11 @@ Thank you!`);
                     if let Some(sections) = frontmatter_data.get("sections") {
                         context.insert("sections", sections);
                     }
+
+                    // Override theme_config with content.md theme_config if it exists
+                    if let Some(content_theme_config) = frontmatter_data.get("theme_config") {
+                        context.insert("theme_config", content_theme_config);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Enable personal site users to override theme configuration on a per-site basis by specifying theme_config in content.md frontmatter. This provides more flexibility for users managing multiple sites with different theme preferences without modifying blogr.toml.

The theme_config from content.md now takes precedence over blogr.toml settings when generating personal sites, allowing for:
- Per-site theme customization
- Dynamic theme configuration
- Better separation of site-specific and global settings

Example usage in content.md:
---
title: "My Site"
theme_config:
  accent_color: "#10b981" show_avatar: true avatar_url: "/static/images/profile.png" ---

This change is backwards compatible - if no theme_config is specified in content.md, the blogr.toml settings are used as before.