### PR TITLE
fix: Add templates to tera in deterministic order

### DIFF
--- a/blogr-cli/src/generator/site.rs
+++ b/blogr-cli/src/generator/site.rs
@@ -176,21 +176,10 @@ Thank you!`);
         // Set up template engine (create empty Tera instance)
         let mut tera = Tera::default();
 
-        // Register theme templates - base template first
-        let templates = theme.templates();
-
-        // Register base template first if it exists
-        if let Some(base_template) = templates.get("base.html") {
-            tera.add_raw_template("base.html", base_template)
-                .map_err(|e| anyhow!("Failed to register base template: {}", e))?;
-        }
-
-        // Register all other templates
-        for (name, template) in &templates {
-            if name != "base.html" {
-                tera.add_raw_template(name, template)
-                    .map_err(|e| anyhow!("Failed to register template '{}': {}", name, e))?;
-            }
+        // Register theme templates
+        for (name, template) in theme.templates() {
+            tera.add_raw_template(name, template)
+                .map_err(|e| anyhow!("Failed to register template '{}': {}", name, e))?;
         }
 
         // Register template functions for URL generation

--- a/blogr-themes/src/dark_minimal/mod.rs
+++ b/blogr-themes/src/dark_minimal/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -116,20 +116,9 @@ impl Theme for DarkMinimalTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/lib.rs
+++ b/blogr-themes/src/lib.rs
@@ -35,9 +35,36 @@ pub struct ConfigOption {
 
 pub trait Theme: Send + Sync {
     fn info(&self) -> ThemeInfo;
-    fn templates(&self) -> HashMap<String, String>;
+    fn templates(&self) -> ThemeTemplates;
     fn assets(&self) -> HashMap<String, Vec<u8>>;
     fn preview_tui_style(&self) -> ratatui::style::Style;
+}
+
+pub struct ThemeTemplates {
+    templates: Vec<(&'static str, &'static str)>,
+}
+
+impl ThemeTemplates {
+    // Base template must be first. This ensure it's registered first with Tera when we iterate through the templates.
+    pub fn new(base_template_name: &'static str, base_template: &'static str) -> Self {
+        Self {
+            templates: vec![(base_template_name, base_template)],
+        }
+    }
+
+    pub fn with_template(mut self, name: &'static str, template: &'static str) -> Self {
+        self.templates.push((name, template));
+        self
+    }
+}
+
+impl IntoIterator for ThemeTemplates {
+    type Item = (&'static str, &'static str);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.templates.into_iter()
+    }
 }
 
 #[must_use]

--- a/blogr-themes/src/minimal_retro/mod.rs
+++ b/blogr-themes/src/minimal_retro/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -96,46 +96,13 @@ impl Theme for MinimalRetroTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        // Base layout template
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        // Index/home page template
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        // Individual post template
-        templates.insert(
-            "post.html".to_string(),
-            include_str!("templates/post.html").to_string(),
-        );
-
-        // Archive/list template
-        templates.insert(
-            "archive.html".to_string(),
-            include_str!("templates/archive.html").to_string(),
-        );
-
-        // Tag page template
-        templates.insert(
-            "tag.html".to_string(),
-            include_str!("templates/tag.html").to_string(),
-        );
-
-        // Tags index template
-        templates.insert(
-            "tags.html".to_string(),
-            include_str!("templates/tags.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
+            .with_template("post.html", include_str!("templates/post.html"))
+            .with_template("archive.html", include_str!("templates/archive.html"))
+            .with_template("tag.html", include_str!("templates/tag.html"))
+            .with_template("tags.html", include_str!("templates/tags.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/minimal_retro/mod.rs
+++ b/blogr-themes/src/minimal_retro/mod.rs
@@ -97,7 +97,7 @@ impl Theme for MinimalRetroTheme {
     }
 
     fn templates(&self) -> ThemeTemplates {
-        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
             .with_template("index.html", include_str!("templates/index.html"))
             .with_template("post.html", include_str!("templates/post.html"))
             .with_template("archive.html", include_str!("templates/archive.html"))

--- a/blogr-themes/src/musashi/mod.rs
+++ b/blogr-themes/src/musashi/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -105,20 +105,9 @@ impl Theme for MusashiTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/obsidian/mod.rs
+++ b/blogr-themes/src/obsidian/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::Style;
 use std::collections::HashMap;
 
@@ -42,35 +42,13 @@ impl Theme for ObsidianTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-        templates.insert(
-            "post.html".to_string(),
-            include_str!("templates/post.html").to_string(),
-        );
-        templates.insert(
-            "archive.html".to_string(),
-            include_str!("templates/archive.html").to_string(),
-        );
-        templates.insert(
-            "tag.html".to_string(),
-            include_str!("templates/tag.html").to_string(),
-        );
-        templates.insert(
-            "tags.html".to_string(),
-            include_str!("templates/tags.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
+            .with_template("post.html", include_str!("templates/post.html"))
+            .with_template("archive.html", include_str!("templates/archive.html"))
+            .with_template("tag.html", include_str!("templates/tag.html"))
+            .with_template("tags.html", include_str!("templates/tags.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/obsidian/mod.rs
+++ b/blogr-themes/src/obsidian/mod.rs
@@ -43,7 +43,7 @@ impl Theme for ObsidianTheme {
     }
 
     fn templates(&self) -> ThemeTemplates {
-        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
             .with_template("index.html", include_str!("templates/index.html"))
             .with_template("post.html", include_str!("templates/post.html"))
             .with_template("archive.html", include_str!("templates/archive.html"))

--- a/blogr-themes/src/slate_portfolio/mod.rs
+++ b/blogr-themes/src/slate_portfolio/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -107,20 +107,9 @@ impl Theme for SlatePortfolioTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/terminal_candy/mod.rs
+++ b/blogr-themes/src/terminal_candy/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -105,40 +105,13 @@ impl Theme for TerminalCandyTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates.insert(
-            "post.html".to_string(),
-            include_str!("templates/post.html").to_string(),
-        );
-
-        templates.insert(
-            "archive.html".to_string(),
-            include_str!("templates/archive.html").to_string(),
-        );
-
-        templates.insert(
-            "tag.html".to_string(),
-            include_str!("templates/tag.html").to_string(),
-        );
-
-        templates.insert(
-            "tags.html".to_string(),
-            include_str!("templates/tags.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
+            .with_template("post.html", include_str!("templates/post.html"))
+            .with_template("archive.html", include_str!("templates/archive.html"))
+            .with_template("tag.html", include_str!("templates/tag.html"))
+            .with_template("tags.html", include_str!("templates/tags.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/terminal_candy/mod.rs
+++ b/blogr-themes/src/terminal_candy/mod.rs
@@ -106,7 +106,7 @@ impl Theme for TerminalCandyTheme {
     }
 
     fn templates(&self) -> ThemeTemplates {
-        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
             .with_template("index.html", include_str!("templates/index.html"))
             .with_template("post.html", include_str!("templates/post.html"))
             .with_template("archive.html", include_str!("templates/archive.html"))

--- a/blogr-themes/src/typewriter/mod.rs
+++ b/blogr-themes/src/typewriter/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -96,20 +96,9 @@ impl Theme for TypewriterTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {


### PR DESCRIPTION
__PROBLEM__
fixes #23 iterating through a HashMap happens in indeterministic order.

__INVESTIGATION__
We need to preserve the existing guarantee that the base template is added first. We need to expand on this to allow the user to deterministically set the order in which templates are added after that.

__SOLUTION__
Create a new type, `ThemeTemplates` that wraps a Vec of the template names and template content. `ThemeTemplates::new` explicitly asks for the base template and puts it at position 0 in the Vec, ensuring that it will always be found first when we iterate through the templates. A builder-style method allows the addition of subsequent themes. Vecs always iterate in deterministic order, so making sure a macro is always added before the templates that rely on it is now possible.