### PR TITLE
Brutja Theme (Blog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,34 @@ show_date_stamp = true             # Vintage date stamp
 cursor_blink = true                # Blinking cursor effect
 ```
 
+### Brutja Theme Configuration
+
+Configure the following fields in `blogr.toml`:
+```toml
+[theme.config]
+css = "static/custom.css"
+hero_title = "Benjamin Corey"
+hero_subtitle = "Software developer in Philadelphia"
+github_username = "bcorey"
+linkedin_username = "benjamin-corey-b18b5517a"
+```
+
+And set the look of the application with these CSS variables:
+```css
+:root {
+    --bg: #f0ffe3;
+    --fg: #7f2172;
+    /* should be an opacity of the fg */
+    --hint: #7f217244;
+    --accent-primary: #a7d3d1;
+    --on-accent-primary: var(--fg);
+    --accent-secondary: #E20018;
+    --on-accent-secondary: white;
+    --accent-tertiary: #fbffb5;
+    --on-accent-tertiary: var(--fg);
+}
+```
+
 ### Available Themes:
 
 - **Minimal Retro** - Clean, artistic design with retro aesthetics (for blogs)
@@ -619,6 +647,7 @@ cursor_blink = true                # Blinking cursor effect
 - **Musashi** - Dynamic modern theme with smooth animations (for personal sites)
 - **Slate Portfolio** - Glassmorphic professional portfolio theme (for personal sites)
 - **Typewriter** - Vintage typewriter aesthetics with nostalgic charm (for personal sites)
+- **Brutja** A minimal brutalist look (for blogs)
 
 **Obsidian Theme Setup**
 

--- a/blogr-cli/src/generator/site.rs
+++ b/blogr-cli/src/generator/site.rs
@@ -176,21 +176,10 @@ Thank you!`);
         // Set up template engine (create empty Tera instance)
         let mut tera = Tera::default();
 
-        // Register theme templates - base template first
-        let templates = theme.templates();
-
-        // Register base template first if it exists
-        if let Some(base_template) = templates.get("base.html") {
-            tera.add_raw_template("base.html", base_template)
-                .map_err(|e| anyhow!("Failed to register base template: {}", e))?;
-        }
-
-        // Register all other templates
-        for (name, template) in &templates {
-            if name != "base.html" {
-                tera.add_raw_template(name, template)
-                    .map_err(|e| anyhow!("Failed to register template '{}': {}", name, e))?;
-            }
+        // Register theme templates
+        for (name, template) in theme.templates() {
+            tera.add_raw_template(name, template)
+                .map_err(|e| anyhow!("Failed to register template '{}': {}", name, e))?;
         }
 
         // Register template functions for URL generation

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -193,6 +193,7 @@ button.search-tag:hover {
     color: var(--bg);
 }
 
+/* make the search tags consistent with other tags */
 button.search-tag::before {
     content: "#"
 }
@@ -1070,28 +1071,9 @@ kbd {
     }
 }
 
-/* Print styles */
-@media print {
-
-    .nav-header,
-    .backlink-pane,
-    .archive-navigation {
-        display: none;
-    }
-
-    .callout {
-        border: 1px solid #ccc;
-        background-color: #f9f9f9;
-    }
-
-    .tag {
-        border: 1px solid #ccc;
-        background-color: #f0f0f0;
-    }
-}
-
 /* Enhanced focus styles for accessibility */
 a:focus,
+button:focus,
 .nav-action-button:focus,
 .tag:focus {
     outline: .1rem solid var(--fg);

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -6,12 +6,15 @@
     /* should be an opacity of the fg */
     --hint: #f3f3f3;
     --accent-primary: #0336FF;
+    --on-accent-primary: white;
     --accent-secondary: #E20018;
+    --on-accent-secondary: white;
     --accent-tertiary: #FFDE03;
+    --on-accent-tertiary: black;
 }
 
 ::selection {
-    color: white;
+    color: var(--on-accent-primary);
     background: var(--accent-primary);
 }
 
@@ -195,7 +198,7 @@ button.search-tag {
 .tag:hover,
 button.search-tag:hover {
     background-color: var(--accent-primary);
-    color: var(--bg);
+    color: var(--on-accent-primary);
 }
 
 /* make the search tags consistent with other tags */
@@ -362,7 +365,7 @@ th {
 
 .navbar-link:hover,
 .navbar-link>a:hover {
-    color: var(--bg);
+    color: var(--on-accent-primary);
     background-color: var(--accent-primary);
 }
 
@@ -497,7 +500,7 @@ th {
 
 .search-highlight {
     background: var(--accent-tertiary);
-    color: var(--fg);
+    color: var(--on-accent-tertiary);
 }
 
 .search-result-actions {
@@ -518,7 +521,7 @@ th {
 }
 
 .search-action:hover {
-    color: var(--bg);
+    color: var(--on-accent-primary);
     background-color: var(--accent-primary);
 }
 
@@ -644,7 +647,7 @@ th {
 
 .nav-action-button:hover {
     background-color: var(--accent-primary);
-    color: var(--fg);
+    color: var(--on-accent-primary);
     text-decoration: none;
 }
 
@@ -888,12 +891,6 @@ th {
     border-bottom: none;
 }
 
-.post-date {
-    min-width: 80px;
-    color: var(--text-muted);
-    font-size: 0.9rem;
-}
-
 .post-content {
     flex: 1;
 }
@@ -933,13 +930,9 @@ th {
     margin-bottom: .1rem;
 }
 
-.post-author {
-    color: var(--text-muted);
-}
-
 .draft-badge {
-    background-color: var(--callout-warning);
-    color: white;
+    background-color: var(--accent-secondary);
+    color: var(--on-accent-secondary);
     padding: 2px 6px;
     font-size: 0.8rem;
     font-weight: 500;
@@ -969,14 +962,13 @@ th {
 .view-archive:hover,
 .view-tags:hover {
     background-color: var(--accent-primary);
-    color: var(--bg);
+    color: var(--on-accent-primary);
 }
 
 /* No posts state */
 .no-posts {
     text-align: center;
     padding: 48px 24px;
-    color: var(--text-muted);
 }
 
 .no-posts-hint {

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -90,35 +90,44 @@ h4,
 h5,
 h6 {
     color: var(--fg);
-    font-weight: 600;
     margin-top: 0;
-    margin-bottom: 0.5em;
+    margin-bottom: 0.5rem;
     line-height: 1.3;
-    text-transform: uppercase;
 }
 
 h1 {
-    font-size: 3rem;
+    font-size: 2rem;
+    text-transform: uppercase;
+    font-weight: 600;
+
 }
 
 h2 {
-    font-size: 2rem;
+    font-size: 1.25rem;
+    text-transform: uppercase;
+    font-weight: 600;
 }
 
 h3 {
     font-size: 1.25rem;
+    font-weight: normal;
 }
 
 h4 {
     font-size: 1rem;
+    text-transform: uppercase;
+    font-weight: 600;
 }
 
 h5 {
-    font-size: .5rem;
+    font-size: 1rem;
+    font-weight: normal;
 }
 
 h6 {
-    font-size: 0.3rem;
+    font-size: .7rem;
+    text-transform: uppercase;
+    font-weight: 600;
 }
 
 hr {

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -1,16 +1,18 @@
 /* Default Obsidian-compatible CSS for Blogr */
 
 :root {
-    --bg: #ffffff;
+    --bg: white;
     --fg: black;
+    /* should be an opacity of the fg */
     --hint: #f3f3f3;
     --accent-primary: #0336FF;
     --accent-secondary: #E20018;
     --accent-tertiary: #FFDE03;
-    --text_color_1: white;
-    --text_color_2: black;
-    --img_blend_mode: normal;
-    --borders: black;
+}
+
+::selection {
+    color: white;
+    background: var(--accent-primary);
 }
 
 html {
@@ -59,7 +61,7 @@ body {
 .markdown-rendered {
     max-width: 900px;
     margin: 0 auto;
-    padding: 20px 20px;
+    padding: 20px 0;
     line-height: 1.6;
     color: var(--fg);
     width: 100%;
@@ -223,7 +225,7 @@ button.search-tag:hover {
     display: flex;
     flex-wrap: wrap;
     justify-content: left;
-    margin: .5rem 0;
+    margin: .2rem 0 .5rem 0;
     border-left: .1rem solid var(--fg);
 }
 
@@ -340,21 +342,65 @@ th {
     font-weight: 600;
 }
 
+.center-column {
+    display: flex;
+    flex-direction: column;
+}
+
+.navbar {
+    display: flex;
+    flex-direction: row;
+    border: .1rem solid var(--fg);
+    border-left: none;
+    border-right: none;
+    margin: 1rem 0;
+    box-shadow: .4rem .3rem var(--hint);
+    vertical-align: middle;
+    box-sizing: border-box;
+    background-color: var(--bg);
+}
+
+.navbar-link {
+    display: flex;
+    border-left: .1rem solid var(--fg);
+    height: 100%;
+    padding: 0 2rem;
+    text-transform: uppercase;
+    align-items: center;
+    background-color: var(--bg);
+}
+
+.navbar-link>a {
+    display: flex;
+    color: inherit;
+    background-color: inherit;
+}
+
+.navbar-link:hover,
+.navbar-link>a:hover {
+    color: var(--bg);
+    background-color: var(--accent-primary);
+}
+
 /* Search Styles */
 .search-form {
     position: relative;
+    display: flex;
     margin: 0;
+    flex-basis: 2;
+    width: 100%;
 }
 
 .search-container {
     display: flex;
     align-items: center;
     background: var(--bg);
-    box-shadow: .4rem .3rem var(--hint);
-    border: .1rem solid var(--fg);
     padding: 6px 12px;
     transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-    max-width: 400px;
+    width: inherit;
+    border: .1rem solid var(--fg);
+    border-top: none;
+    border-bottom: none;
 }
 
 .search-container:focus-within {
@@ -402,16 +448,19 @@ th {
     left: 0;
     right: 0;
     background: var(--bg);
-    border-top: none;
     border: .1rem solid var(--fg);
     box-shadow: .4rem .3rem var(--hint);
     overflow-y: auto;
     z-index: 1000;
-    margin-top: -1px;
+    margin-top: 0px;
 }
 
 .search-results-visible {
     display: block !important;
+}
+
+.search-result-item:first-child {
+    border-top: none;
 }
 
 .search-result-item {
@@ -527,7 +576,7 @@ th {
 @media (max-width: 768px) {
     .markdown-rendered {
         max-width: 100%;
-        padding: 20px 16px;
+        padding: 20px 0;
     }
 
     .inline-title {
@@ -905,6 +954,7 @@ th {
 .post-meta {
     font-size: 0.9rem;
     font-style: italic;
+    margin-bottom: .1rem;
 }
 
 .post-author {
@@ -992,14 +1042,14 @@ kbd {
 @media (max-width: 1200px) {
     .markdown-rendered {
         max-width: 800px !important;
-        padding: 20px 24px !important;
+        padding: 20px 0 !important;
     }
 }
 
 @media (max-width: 768px) {
     .markdown-rendered {
         max-width: 100% !important;
-        padding: 20px 16px !important;
+        padding: 20px 0 !important;
     }
 
     .frontmatter-section-simple,
@@ -1034,7 +1084,7 @@ kbd {
 
 @media (max-width: 480px) {
     .markdown-rendered {
-        padding: 20px 12px;
+        padding: 20px 0;
     }
 
     .callout {

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -155,30 +155,6 @@ a:hover {
     position: relative;
 }
 
-.callout[data-callout="info"] {
-    border-left-color: var(--callout-info);
-}
-
-.callout[data-callout="tip"] {
-    border-left-color: var(--callout-tip);
-}
-
-.callout[data-callout="warning"] {
-    border-left-color: var(--callout-warning);
-}
-
-.callout[data-callout="error"] {
-    border-left-color: var(--callout-error);
-}
-
-.callout[data-callout="abstract"] {
-    border-left-color: var(--callout-abstract);
-}
-
-.callout[data-callout="note"] {
-    border-left-color: var(--callout-note);
-}
-
 .callout-title {
     font-weight: 600;
     margin-bottom: 8px;
@@ -207,16 +183,18 @@ button.search-tag {
     height: fit-content;
     font-size: .9rem;
     border: .1rem solid var(--fg);
-    border-left: none;
     box-shadow: .4rem .3rem var(--hint);
+    margin-left: -.1rem;
 }
-
-
 
 .tag:hover,
 button.search-tag:hover {
     background-color: var(--accent-primary);
     color: var(--bg);
+}
+
+button.search-tag::before {
+    content: "#"
 }
 
 .post-tags,
@@ -225,8 +203,8 @@ button.search-tag:hover {
     display: flex;
     flex-wrap: wrap;
     justify-content: left;
-    margin: .2rem 0 .5rem 0;
-    border-left: .1rem solid var(--fg);
+    margin: .2rem 0 .5rem .1rem;
+    row-gap: .3rem;
 }
 
 /* Embedded content */
@@ -512,7 +490,7 @@ th {
 }
 
 .search-highlight {
-    background: var(--callout-note);
+    background: var(--accent-tertiary);
     color: var(--fg);
 }
 
@@ -928,6 +906,10 @@ th {
 
 .post-card {
     margin: 1.5rem 0;
+}
+
+.post-title {
+    margin-bottom: .2rem;
 }
 
 .post-title a {

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -782,37 +782,18 @@ th {
 }
 
 .search-result-file-match-content {
-    color: var(--text-muted);
+    color: var(--fg);
     font-size: 0.9rem;
 }
 
 .search-result-count {
-    color: var(--text-muted);
+    color: var(--fg);
     font-size: 0.9rem;
 }
 
 /* Tag enhancements */
 .tag-pane {
     margin: 24px 0;
-}
-
-.tag-pane-title {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: .1rem solid var(--fg);
-}
-
-.tag-pane-title-text {
-    font-weight: 600;
-    font-size: 1.1rem;
-}
-
-.tag-pane-title-count {
-    color: var(--text-muted);
-    font-size: 0.9em;
 }
 
 .tag-container-grid {
@@ -877,18 +858,6 @@ th {
 
 .year-posts {
     margin-left: 16px;
-}
-
-.archive-post {
-    display: flex;
-    gap: 16px;
-    margin-bottom: 16px;
-    padding: 12px 0;
-    border-bottom: .1rem solid var(--fg);
-}
-
-.archive-post:last-child {
-    border-bottom: none;
 }
 
 .post-content {
@@ -1027,11 +996,6 @@ kbd {
         gap: 8px;
     }
 
-    .archive-post {
-        flex-direction: column;
-        gap: 8px;
-    }
-
     .post-date {
         min-width: auto;
     }
@@ -1122,175 +1086,6 @@ button:focus,
     .markdown-embed {
         margin: 12px 0;
         padding: 12px;
-    }
-}
-
-/* Newsletter Subscription Styles */
-.callout[data-callout="newsletter"] {
-    --callout-color: 99, 102, 241;
-    --callout-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z'/%3E%3Cpolyline points='22,6 12,13 2,6'/%3E%3C/svg%3E");
-    overflow: hidden;
-    position: relative;
-    transition: all 0.3s ease;
-}
-
-.callout[data-callout="newsletter"]:hover {
-    transform: translateY(-1px);
-    box-shadow: .4rem .3rem var(--hint);
-}
-
-.callout[data-callout="newsletter"]::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: linear-gradient(90deg,
-            rgba(var(--callout-color), 0.7),
-            rgba(var(--callout-color), 0.5));
-    opacity: 0.8;
-}
-
-.newsletter-subscription {
-    margin: 8px 0 0 0;
-}
-
-.newsletter-header h3 {
-    font-size: var(--font-ui-large);
-    color: var(--fg);
-    margin: 0 0 8px 0;
-    font-weight: 500;
-    letter-spacing: -0.005rem;
-    line-height: 1.3;
-}
-
-.newsletter-header p {
-    color: var(--text-muted);
-    margin: 0 0 20px 0;
-    font-size: var(--font-ui-small);
-    line-height: 1.5;
-    font-weight: 400;
-}
-
-.newsletter-form {
-    margin: 0;
-}
-
-.newsletter-input-group {
-    display: flex;
-    gap: 0;
-    background: var(--bg);
-    border: .1rem solid var(--fg);
-    overflow: hidden;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-    margin-bottom: 12px;
-}
-
-.newsletter-input-group:focus-within {
-    border-color: rgba(var(--accent-primary), 0.5);
-    box-shadow: .4rem .3rem var(--background-modifier-active);
-    background: var(--bg);
-}
-
-.newsletter-email-input {
-    flex: 1;
-    padding: 10px 16px;
-    font-size: var(--font-ui-small);
-    font-weight: 400;
-    border: none;
-    background: transparent;
-    color: var(--fg);
-    outline: none;
-    transition: color 0.2s ease;
-}
-
-.newsletter-email-input::placeholder {
-    color: var(--text-faint);
-    font-style: normal;
-    font-weight: 400;
-}
-
-.newsletter-submit-btn {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 10px 20px;
-    font-size: var(--font-ui-small);
-    font-weight: 500;
-    background: linear-gradient(135deg,
-            rgb(var(--callout-color)),
-            rgba(var(--callout-color), 0.9));
-    color: white;
-    border: none;
-    cursor: pointer;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-    white-space: nowrap;
-    letter-spacing: 0.01rem;
-    box-shadow: .4rem .3rem var(--background-modifier-active);
-}
-
-.newsletter-submit-btn:hover {
-    background: linear-gradient(135deg,
-            rgba(var(--callout-color), 0.9),
-            rgba(var(--callout-color), 0.8));
-    transform: translateY(-1px);
-}
-
-.newsletter-submit-btn:active {
-    transform: translateY(0);
-}
-
-.btn-icon {
-    transition: transform 0.2s ease;
-}
-
-.newsletter-submit-btn:hover .btn-icon {
-    transform: translateX(1px);
-}
-
-.newsletter-privacy {
-    text-align: center;
-    font-size: var(--font-ui-smaller);
-    color: var(--text-faint);
-    margin: 0;
-    line-height: 1.4;
-}
-
-.newsletter-fallback {
-    text-align: center;
-    font-size: var(--font-ui-small);
-    margin: 12px 0 0 0;
-}
-
-.newsletter-fallback a {
-    color: var(--link-color);
-    text-decoration: underline;
-    text-decoration-color: var(--link-color-hover);
-    transition: all 0.2s ease;
-}
-
-.newsletter-fallback a:hover {
-    color: var(--link-color-hover);
-}
-
-/* Responsive design for newsletter */
-@media (max-width: 600px) {
-    .newsletter-input-group {
-        flex-direction: column;
-        gap: 0;
-    }
-
-    .newsletter-email-input {
-        padding: 10px 16px;
-        font-size: var(--font-ui-smaller);
-        border-bottom: .1rem solid var(--fg);
-    }
-
-    .newsletter-submit-btn {
-        padding: 10px 16px;
-        font-size: var(--font-ui-smaller);
-        justify-content: center;
     }
 }
 

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -1,5 +1,3 @@
-/* Default Obsidian-compatible CSS for Blogr */
-
 :root {
     --bg: white;
     --fg: black;

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -1,0 +1,1308 @@
+/* Default Obsidian-compatible CSS for Blogr */
+
+:root {
+    --bg: #ffffff;
+    --fg: black;
+    --hint: #f3f3f3;
+    --accent-primary: #0336FF;
+    --accent-secondary: #E20018;
+    --accent-tertiary: #FFDE03;
+    --text_color_1: white;
+    --text_color_2: black;
+    --img_blend_mode: normal;
+    --borders: black;
+}
+
+html {
+    /* font-size: 62.5%; */
+    font-size: 82.5%;
+
+}
+
+body {
+    font-family: Helvetica, sans-serif;
+    background-color: var(--bg);
+    color: var(--fg);
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+}
+
+.app-container {
+    min-height: 100vh;
+    background-color: var(--bg);
+}
+
+.workspace {
+    display: flex;
+    width: 100%;
+    min-height: 100vh;
+}
+
+.workspace-leaf-content {
+    flex: 1;
+    background-color: var(--bg);
+    display: flex;
+    justify-content: center;
+    width: 100%;
+}
+
+.markdown-preview-view {
+    padding: 0;
+    background-color: var(--bg);
+    width: 100%;
+    max-width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.markdown-rendered {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 20px 20px;
+    line-height: 1.6;
+    color: var(--fg);
+    width: 100%;
+    box-sizing: border-box;
+}
+
+/* Typography */
+.inline-title {
+    font-size: 2.25em;
+    font-weight: 700;
+    margin-bottom: 0.5em;
+    color: var(--fg);
+    border: none;
+    background: transparent;
+    display: block;
+    line-height: 1.2;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    color: var(--fg);
+    font-weight: 600;
+    margin-top: 0;
+    margin-bottom: 0.5em;
+    line-height: 1.3;
+    text-transform: uppercase;
+}
+
+h1 {
+    font-size: 3rem;
+}
+
+h2 {
+    font-size: 2rem;
+}
+
+h3 {
+    font-size: 1.25rem;
+}
+
+h4 {
+    font-size: 1rem;
+}
+
+h5 {
+    font-size: .5rem;
+}
+
+h6 {
+    font-size: 0.3rem;
+}
+
+/* Links */
+a {
+    color: var(--accent-primary);
+    text-decoration: none;
+}
+
+a:hover {
+    color: var(--accent-primary);
+    text-decoration: underline;
+}
+
+.hero-section {
+    margin-bottom: 3rem;
+    width: 100%;
+    border-bottom: .1rem solid var(--fg);
+}
+
+
+.internal-link {
+    color: var(--accent-primary);
+    text-decoration: none;
+}
+
+.internal-link:hover {
+    color: var(--accent-primary);
+    text-decoration: underline;
+}
+
+/* Callouts */
+.callout {
+    padding: 0 16px;
+    margin: 16px 0;
+    border-left: .1rem solid var(--fg);
+    background-color: var(--bg);
+    position: relative;
+}
+
+.callout[data-callout="info"] {
+    border-left-color: var(--callout-info);
+}
+
+.callout[data-callout="tip"] {
+    border-left-color: var(--callout-tip);
+}
+
+.callout[data-callout="warning"] {
+    border-left-color: var(--callout-warning);
+}
+
+.callout[data-callout="error"] {
+    border-left-color: var(--callout-error);
+}
+
+.callout[data-callout="abstract"] {
+    border-left-color: var(--callout-abstract);
+}
+
+.callout[data-callout="note"] {
+    border-left-color: var(--callout-note);
+}
+
+.callout-title {
+    font-weight: 600;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.callout-content {
+    margin: 0;
+}
+
+/* Tags */
+.tag,
+button.search-tag {
+    background-color: var(--bg);
+    color: var(--fg);
+    text-decoration: none;
+    display: inline-block;
+    transition: all 0.2s ease;
+    padding: .1rem .5rem;
+    margin-right: 0rem;
+    width: fit-content;
+    cursor: pointer;
+    text-decoration: none;
+    height: fit-content;
+    font-size: .9rem;
+    border: .1rem solid var(--fg);
+    border-left: none;
+    box-shadow: .4rem .3rem var(--hint);
+}
+
+
+
+.tag:hover,
+button.search-tag:hover {
+    background-color: var(--accent-primary);
+    color: var(--bg);
+}
+
+.post-tags,
+.search-result-tags {
+    width: fit-content;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: left;
+    margin: .5rem 0;
+    border-left: .1rem solid var(--fg);
+}
+
+/* Embedded content */
+.markdown-embed {
+    border: 1px solid var(--fg);
+    margin: 16px 0;
+    padding: 16px;
+    background-color: var(--bg);
+}
+
+.markdown-embed-title {
+    font-weight: 600;
+    margin-bottom: 8px;
+    font-size: 1.1rem;
+}
+
+.markdown-embed-link {
+    color: var(--accent-primary);
+    text-decoration: none;
+}
+
+.markdown-embed-link:hover {
+    color: var(--accent-primary-hover);
+    text-decoration: underline;
+}
+
+/* Navigation elements */
+.nav-folder-children {
+    margin: 16px 0;
+}
+
+.nav-file {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--fg);
+}
+
+.nav-file:last-child {
+    border-bottom: none;
+}
+
+.nav-file-title {
+    flex: 1;
+}
+
+.nav-file-title-content {
+    color: var(--fg);
+}
+
+.nav-file-tag {
+    margin-left: 12px;
+}
+
+/* Code */
+code {
+    background-color: var(--hint);
+    padding: 2px 4px;
+    font-family: "SF Mono", Monaco, "Roboto Mono", monospace;
+    font-size: 0.9rem;
+    color: var(--fg);
+}
+
+pre {
+    background-color: var(--hint);
+    padding: 16px;
+    overflow-x: auto;
+}
+
+pre code {
+    background: none;
+    padding: 0;
+}
+
+/* Blockquotes */
+blockquote {
+    border-left: 4px solid var(--accent-primary);
+    padding-left: 16px;
+    margin: 16px 0;
+    font-style: italic;
+    color: var(--text-muted);
+    background-color: var(--bg);
+    padding: 16px;
+}
+
+/* Lists */
+ul,
+ol {
+    padding-left: 24px;
+}
+
+li {
+    margin: 4px 0;
+}
+
+/* Tables */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0;
+}
+
+th,
+td {
+    border: 1px solid var(--fg);
+    padding: 8px 12px;
+    text-align: left;
+}
+
+th {
+    background-color: var(--bg);
+    font-weight: 600;
+}
+
+/* Search Styles */
+.search-form {
+    position: relative;
+    margin: 0;
+}
+
+.search-container {
+    display: flex;
+    align-items: center;
+    background: var(--bg);
+    box-shadow: .4rem .3rem var(--hint);
+    border: .1rem solid var(--fg);
+    padding: 6px 12px;
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    max-width: 400px;
+}
+
+.search-container:focus-within {
+    background: var(--bg);
+}
+
+#search-input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    padding: 4px 8px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--fg);
+    outline: none;
+    transition: color 0.2s ease;
+}
+
+#search-input::placeholder {
+    color: var(--text-faint);
+    font-weight: 400;
+}
+
+.search-button {
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+    color: var(--text-muted);
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.search-button:hover {
+    color: var(--accent-primary);
+    background: var(--bg);
+}
+
+.search-results {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--bg);
+    border-top: none;
+    border: .1rem solid var(--fg);
+    box-shadow: .4rem .3rem var(--hint);
+    overflow-y: auto;
+    z-index: 1000;
+    margin-top: -1px;
+}
+
+.search-results-visible {
+    display: block !important;
+}
+
+.search-result-item {
+    padding: 12px;
+    border-top: .1rem solid var(--fg);
+    transition: background-color 0.2s ease;
+}
+
+.search-result-item:last-child {
+    border-bottom: none;
+}
+
+.search-result-item:hover {
+    background-color: var(--bg);
+}
+
+.search-result-item.is-active {
+    background-color: var(--bg);
+}
+
+.search-result-title {
+    margin: 0 0 6px 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--fg);
+}
+
+.search-result-link {
+    color: var(--fg);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.search-result-link:hover {
+    color: var(--interactive-accent);
+}
+
+.search-result-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+    color: var(--fg);
+}
+
+.search-result-excerpt {
+    margin: 0;
+    line-height: 1.4;
+}
+
+.search-highlight {
+    background: var(--callout-note);
+    color: var(--fg);
+}
+
+.search-result-actions {
+    display: flex;
+    margin-top: 8px;
+    gap: .5rem;
+}
+
+.search-action {
+    background: var(--bg);
+    color: var(--fg);
+    border: 1px solid var(--fg);
+    padding: 4px 8px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: .4rem .3rem var(--hint);
+}
+
+.search-action:hover {
+    color: var(--bg);
+    background-color: var(--accent-primary);
+}
+
+.search-results-footer {
+    padding: 8px 12px;
+    display: flex;
+    justify-content: center;
+    background: var(--bg);
+}
+
+.search-results-more {
+    background: var(--interactive-accent);
+    color: #fff;
+    border: none;
+    padding: 6px 12px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.search-results-more:hover {
+    background: var(--interactive-accent-hover);
+}
+
+.search-no-results,
+.search-error {
+    padding: 16px;
+    text-align: center;
+    box-shadow: .4rem .3rem var(--hint);
+}
+
+.search-suggestions {
+    font-size: 14px;
+    margin-top: 6px;
+}
+
+/* Responsive design */
+
+@media (max-width: 768px) {
+    .markdown-rendered {
+        max-width: 100%;
+        padding: 20px 16px;
+    }
+
+    .inline-title {
+        font-size: 1.8rem;
+    }
+
+    .search-container {
+        max-width: 100%;
+    }
+
+    .search-results {
+        left: 0;
+        right: 0;
+    }
+}
+
+/* Additional Obsidian-specific styles not covered in base.html */
+
+/* Frontmatter styling */
+.frontmatter-container {
+    margin: 16px 0;
+    padding: 12px;
+    background-color: var(--bg);
+    border: 1px solid var(--fg);
+}
+
+.frontmatter-section {
+    margin: 0;
+}
+
+.frontmatter-section-simple {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+}
+
+.frontmatter-alias-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+}
+
+.frontmatter-alias {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.frontmatter-alias-icon {
+    font-size: 1rem;
+}
+
+/* Navigation and workspace enhancements */
+.nav-header {
+    padding: 16px 0;
+    border-bottom: .1rem solid var(--fg);
+    margin-bottom: 24px;
+}
+
+.nav-buttons-container {
+    display: flex;
+    gap: 8px;
+}
+
+.nav-action-button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background-color: var(--bg);
+    color: var(--fg);
+    text-decoration: none;
+    border: .1rem solid var(--fg);
+    transition: all 0.2s ease;
+    font-size: 0.9rem;
+}
+
+.nav-action-button:hover {
+    background-color: var(--accent-primary);
+    color: var(--fg);
+    text-decoration: none;
+}
+
+.nav-action-button svg {
+    width: 16px;
+    height: 16px;
+}
+
+/* Enhanced CodeMirror styling */
+.mod-cm6 {
+    margin: 24px 0;
+}
+
+.is-readable-line-width {
+    max-width: none;
+}
+
+.cm-editor {
+    background-color: transparent;
+}
+
+.cm-scroller {
+    font-family: inherit;
+    line-height: 1.6;
+}
+
+.cm-content {
+    padding: 0;
+    min-height: auto;
+}
+
+/* Tree/folder navigation styling */
+.tree-item-self {
+    padding: 8px 0;
+    font-weight: 600;
+    color: var(--fg);
+    border-bottom: .1rem solid var(--fg);
+    margin-bottom: 16px;
+}
+
+.tree-item-inner {
+    font-size: 1.1rem;
+}
+
+.nav-folder-title-content {
+    color: var(--fg);
+    font-weight: 600;
+}
+
+.nav-folder {
+    margin: 24px 0;
+}
+
+.nav-folder-children {
+    margin: 16px 0;
+}
+
+/* Enhanced embedded content */
+.embedded-backlinks {
+    margin: 32px 0;
+}
+
+.markdown-embed {
+    border: .1rem solid var(--fg);
+    margin: 16px 0;
+    padding: 16px;
+    background-color: var(--bg);
+    transition: all 0.2s ease;
+}
+
+.markdown-embed:hover {
+    border-color: var(--accent-primary);
+    background-color: var(--bg);
+}
+
+.markdown-embed-title {
+    font-weight: 600;
+    margin-bottom: 12px;
+    font-size: 1.1rem;
+}
+
+.markdown-embed-link {
+    color: var(--accent-primary);
+    text-decoration: none;
+}
+
+.markdown-embed-link:hover {
+    color: var(--accent-primary-hover);
+    text-decoration: underline;
+}
+
+.markdown-embed-content {
+    margin: 12px 0 0 0;
+}
+
+.markdown-embed-excerpt {
+    font-style: italic;
+    color: var(--text-muted);
+    margin: 8px 0;
+    padding-left: 12px;
+    border-left: .1rem solid var(--fg);
+}
+
+.embedded-content-preview {
+    margin-top: 12px;
+}
+
+/* Search result styling */
+.search-result-container {
+    margin: 24px 0;
+}
+
+.search-result-file-matches {
+    margin: 16px 0;
+}
+
+.search-result-file-title {
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+.search-result-file-match {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: .1rem solid var(--fg);
+}
+
+.search-result-file-match:last-child {
+    border-bottom: none;
+}
+
+.search-result-file-match-content {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.search-result-count {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+/* Tag enhancements */
+.tag-pane {
+    margin: 24px 0;
+}
+
+.tag-pane-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    padding-bottom: 8px;
+    border-bottom: .1rem solid var(--fg);
+}
+
+.tag-pane-title-text {
+    font-weight: 600;
+    font-size: 1.1rem;
+}
+
+.tag-pane-title-count {
+    color: var(--text-muted);
+    font-size: 0.9em;
+}
+
+.tag-container-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.tag-item {
+    display: inline-block;
+}
+
+.tag-with-count {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.tag-count {
+    background-color: var(--bg);
+    color: var(--fg);
+    padding: 2px 6px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+/* Backlink pane styling */
+.backlink-pane {
+    margin: 32px 0;
+    padding-top: 24px;
+    border-top: .1rem solid var(--fg);
+}
+
+/* Metadata container */
+.metadata-container {
+    margin: 24px 0;
+}
+
+/* Archive page specific styles */
+.archive-page {
+    /* This will be overridden by the Obsidian structure, but keeping for compatibility */
+    display: block;
+}
+
+.archive-header {
+    margin-bottom: 32px;
+}
+
+.archive-title {
+    font-size: 2rem;
+    margin-bottom: 8px;
+}
+
+.archive-subtitle {
+    color: var(--text-muted);
+    font-size: 1.1rem;
+}
+
+.archive-content {
+    margin: 24px 0;
+}
+
+.archive-year {
+    margin-bottom: 32px;
+}
+
+.year-title {
+    font-size: 1.5rem;
+    margin-bottom: 16px;
+    color: var(--accent-primary);
+    border-bottom: 2px solid var(--accent-primary);
+    padding-bottom: 8px;
+}
+
+.year-posts {
+    margin-left: 16px;
+}
+
+.archive-post {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 16px;
+    padding: 12px 0;
+    border-bottom: .1rem solid var(--fg);
+}
+
+.archive-post:last-child {
+    border-bottom: none;
+}
+
+.post-date {
+    min-width: 80px;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.post-content {
+    flex: 1;
+}
+
+.post-card {
+    margin: 1.5rem 0;
+}
+
+.post-title a {
+    color: var(--fg);
+    text-decoration: none;
+}
+
+.post-title a:hover {
+    color: var(--accent-primary);
+    text-decoration: underline;
+}
+
+.post-description {
+    margin: 8px 0;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.post-excerpt p {
+    margin: 0;
+}
+
+.post-meta {
+    font-size: 0.9rem;
+    font-style: italic;
+}
+
+.post-author {
+    color: var(--text-muted);
+}
+
+.draft-badge {
+    background-color: var(--callout-warning);
+    color: white;
+    padding: 2px 6px;
+    font-size: 0.8rem;
+    font-weight: 500;
+}
+
+.archive-navigation {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 32px;
+    padding-top: 16px;
+    border-top: .1rem solid var(--fg);
+}
+
+.back-home,
+.view-archive,
+.view-tags {
+    color: var(--fg);
+    text-decoration: none;
+    border: .1rem solid var(--fg);
+    transition: all 0.2s ease;
+    box-shadow: .4rem .3rem var(--hint);
+    padding: .4rem .8rem;
+}
+
+.back-home:hover,
+.view-archive:hover,
+.view-tags:hover {
+    background-color: var(--accent-primary);
+    color: var(--bg);
+}
+
+/* No posts state */
+.no-posts {
+    text-align: center;
+    padding: 48px 24px;
+    color: var(--text-muted);
+}
+
+.no-posts-hint {
+    font-size: 0.9rem;
+    margin-top: 8px;
+}
+
+/* Tags page specific styles */
+.tags-page {
+    /* This will be overridden by the Obsidian structure, but keeping for compatibility */
+    display: block;
+}
+
+.tags-header {
+    margin-bottom: 32px;
+}
+
+.tags-title {
+    font-size: 2rem;
+    margin-bottom: 8px;
+}
+
+.tags-subtitle {
+    color: var(--text-muted);
+    font-size: 1.1rem;
+}
+
+/* Keyboard shortcut styling */
+kbd {
+    background-color: var(--bg);
+    border: .1rem solid var(--fg);
+    padding: 2px 6px;
+    font-family: 'SF Mono', Monaco, 'Roboto Mono', monospace;
+    font-size: 0.85rem;
+    color: var(--fg);
+}
+
+/* Responsive design improvements */
+@media (max-width: 1200px) {
+    .markdown-rendered {
+        max-width: 800px !important;
+        padding: 20px 24px !important;
+    }
+}
+
+@media (max-width: 768px) {
+    .markdown-rendered {
+        max-width: 100% !important;
+        padding: 20px 16px !important;
+    }
+
+    .frontmatter-section-simple,
+    .frontmatter-alias-list {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    .archive-post {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .post-date {
+        min-width: auto;
+    }
+
+    .archive-navigation {
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .tag-container-grid {
+        gap: 6px;
+    }
+
+    .nav-buttons-container {
+        flex-wrap: wrap;
+    }
+}
+
+@media (max-width: 480px) {
+    .markdown-rendered {
+        padding: 20px 12px;
+    }
+
+    .callout {
+        padding: 0 12px;
+    }
+
+    .markdown-embed {
+        padding: 12px;
+    }
+
+    .frontmatter-container {
+        padding: 8px;
+    }
+}
+
+/* Print styles */
+@media print {
+
+    .nav-header,
+    .backlink-pane,
+    .archive-navigation {
+        display: none;
+    }
+
+    .callout {
+        border: 1px solid #ccc;
+        background-color: #f9f9f9;
+    }
+
+    .tag {
+        border: 1px solid #ccc;
+        background-color: #f0f0f0;
+    }
+}
+
+/* Enhanced focus styles for accessibility */
+a:focus,
+.nav-action-button:focus,
+.tag:focus {
+    outline: .1rem solid var(--fg);
+    outline-offset: 2px;
+}
+
+
+/* Additional missing styles for template elements */
+.tree-item-flair {
+    background-color: var(--tag-background);
+    color: var(--tag-color);
+    padding: 2px 6px;
+    font-size: 0.75em;
+    font-weight: 500;
+    margin-left: 8px;
+}
+
+.search-excerpt {
+    font-style: italic;
+    color: var(--fg);
+    margin: 8px 0;
+    padding-left: 12px;
+    border-left: .1rem solid var(--fg);
+    background-color: var(--bg);
+    padding: 8px 12px;
+}
+
+/* Ensure proper content variable handling */
+.cm-content {
+    /* Override any CodeMirror specific styles that might interfere */
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    color: inherit;
+}
+
+/* Additional responsive improvements */
+@media (max-width: 600px) {
+    .frontmatter-container {
+        margin: 12px 0;
+        padding: 8px;
+    }
+
+    .callout {
+        margin: 12px 0;
+        padding: 0 12px;
+    }
+
+    .markdown-embed {
+        margin: 12px 0;
+        padding: 12px;
+    }
+}
+
+/* Newsletter Subscription Styles */
+.callout[data-callout="newsletter"] {
+    --callout-color: 99, 102, 241;
+    --callout-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'%3E%3Cpath d='M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z'/%3E%3Cpolyline points='22,6 12,13 2,6'/%3E%3C/svg%3E");
+    overflow: hidden;
+    position: relative;
+    transition: all 0.3s ease;
+}
+
+.callout[data-callout="newsletter"]:hover {
+    transform: translateY(-1px);
+    box-shadow: .4rem .3rem var(--hint);
+}
+
+.callout[data-callout="newsletter"]::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg,
+            rgba(var(--callout-color), 0.7),
+            rgba(var(--callout-color), 0.5));
+    opacity: 0.8;
+}
+
+.newsletter-subscription {
+    margin: 8px 0 0 0;
+}
+
+.newsletter-header h3 {
+    font-size: var(--font-ui-large);
+    color: var(--fg);
+    margin: 0 0 8px 0;
+    font-weight: 500;
+    letter-spacing: -0.005rem;
+    line-height: 1.3;
+}
+
+.newsletter-header p {
+    color: var(--text-muted);
+    margin: 0 0 20px 0;
+    font-size: var(--font-ui-small);
+    line-height: 1.5;
+    font-weight: 400;
+}
+
+.newsletter-form {
+    margin: 0;
+}
+
+.newsletter-input-group {
+    display: flex;
+    gap: 0;
+    background: var(--bg);
+    border: .1rem solid var(--fg);
+    overflow: hidden;
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    margin-bottom: 12px;
+}
+
+.newsletter-input-group:focus-within {
+    border-color: rgba(var(--accent-primary), 0.5);
+    box-shadow: .4rem .3rem var(--background-modifier-active);
+    background: var(--bg);
+}
+
+.newsletter-email-input {
+    flex: 1;
+    padding: 10px 16px;
+    font-size: var(--font-ui-small);
+    font-weight: 400;
+    border: none;
+    background: transparent;
+    color: var(--fg);
+    outline: none;
+    transition: color 0.2s ease;
+}
+
+.newsletter-email-input::placeholder {
+    color: var(--text-faint);
+    font-style: normal;
+    font-weight: 400;
+}
+
+.newsletter-submit-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 20px;
+    font-size: var(--font-ui-small);
+    font-weight: 500;
+    background: linear-gradient(135deg,
+            rgb(var(--callout-color)),
+            rgba(var(--callout-color), 0.9));
+    color: white;
+    border: none;
+    cursor: pointer;
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    white-space: nowrap;
+    letter-spacing: 0.01rem;
+    box-shadow: .4rem .3rem var(--background-modifier-active);
+}
+
+.newsletter-submit-btn:hover {
+    background: linear-gradient(135deg,
+            rgba(var(--callout-color), 0.9),
+            rgba(var(--callout-color), 0.8));
+    transform: translateY(-1px);
+}
+
+.newsletter-submit-btn:active {
+    transform: translateY(0);
+}
+
+.btn-icon {
+    transition: transform 0.2s ease;
+}
+
+.newsletter-submit-btn:hover .btn-icon {
+    transform: translateX(1px);
+}
+
+.newsletter-privacy {
+    text-align: center;
+    font-size: var(--font-ui-smaller);
+    color: var(--text-faint);
+    margin: 0;
+    line-height: 1.4;
+}
+
+.newsletter-fallback {
+    text-align: center;
+    font-size: var(--font-ui-small);
+    margin: 12px 0 0 0;
+}
+
+.newsletter-fallback a {
+    color: var(--link-color);
+    text-decoration: underline;
+    text-decoration-color: var(--link-color-hover);
+    transition: all 0.2s ease;
+}
+
+.newsletter-fallback a:hover {
+    color: var(--link-color-hover);
+}
+
+/* Responsive design for newsletter */
+@media (max-width: 600px) {
+    .newsletter-input-group {
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .newsletter-email-input {
+        padding: 10px 16px;
+        font-size: var(--font-ui-smaller);
+        border-bottom: .1rem solid var(--fg);
+    }
+
+    .newsletter-submit-btn {
+        padding: 10px 16px;
+        font-size: var(--font-ui-smaller);
+        justify-content: center;
+    }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -118,6 +118,11 @@ h6 {
     font-size: 0.3rem;
 }
 
+hr {
+    border: .05rem solid var(--fg);
+    height: 0;
+}
+
 /* Links */
 a {
     color: var(--accent-primary);

--- a/blogr-themes/src/brutja/assets/brutja-default.css
+++ b/blogr-themes/src/brutja/assets/brutja-default.css
@@ -832,20 +832,8 @@ th {
 
 /* Backlink pane styling */
 .backlink-pane {
-    margin: 32px 0;
-    padding-top: 24px;
+    margin: 1rem 0;
     border-top: .1rem solid var(--fg);
-}
-
-/* Metadata container */
-.metadata-container {
-    margin: 24px 0;
-}
-
-/* Archive page specific styles */
-.archive-page {
-    /* This will be overridden by the Obsidian structure, but keeping for compatibility */
-    display: block;
 }
 
 .archive-header {

--- a/blogr-themes/src/brutja/mod.rs
+++ b/blogr-themes/src/brutja/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Theme, ThemeInfo, ThemeTemplates};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::Style;
 use std::collections::HashMap;
 
@@ -13,7 +13,53 @@ impl BrutjaTheme {
 
 impl Theme for BrutjaTheme {
     fn info(&self) -> ThemeInfo {
-        let schema = HashMap::new();
+        let mut schema = HashMap::new();
+        schema.insert(
+            "css".to_string(),
+            ConfigOption {
+                option_type: "string".to_string(),
+                default: "static/styles.css".to_string(),
+                description: "Path to user CSS (served from /static/)".to_string(),
+            },
+        );
+
+        schema.insert(
+            "hero_title".to_string(),
+            ConfigOption {
+                option_type: "string".to_string(),
+                default: "Welcome".to_string(),
+                description: "Homepage hero title".to_string(),
+            },
+        );
+
+        schema.insert(
+            "hero_subtitle".to_string(),
+            ConfigOption {
+                option_type: "string".to_string(),
+                default: "Customize your theme".to_string(),
+                description: "Homepage hero subtitle".to_string(),
+            },
+        );
+
+        schema.insert(
+            "github_username".to_string(),
+            ConfigOption {
+                option_type: "string".to_string(),
+                default: String::new(),
+                description: "Your github username".to_string(),
+            },
+        );
+
+        schema.insert(
+            "linkedin_username".to_string(),
+            ConfigOption {
+                option_type: "string".to_string(),
+                default: String::new(),
+                description:
+                    "The last segment of your linkedin profile URL. Do not include slashes."
+                        .to_string(),
+            },
+        );
 
         ThemeInfo {
             name: "Brutja".to_string(),
@@ -37,7 +83,7 @@ impl Theme for BrutjaTheme {
     fn assets(&self) -> HashMap<String, Vec<u8>> {
         let mut assets = HashMap::new();
 
-        // Bundle a default Obsidian-compatible CSS
+        // Bundle the brutja theme defaults
         assets.insert(
             "css/brutja-default.css".to_string(),
             include_bytes!("assets/brutja-default.css").to_vec(),

--- a/blogr-themes/src/brutja/mod.rs
+++ b/blogr-themes/src/brutja/mod.rs
@@ -1,0 +1,82 @@
+use crate::{Theme, ThemeInfo};
+use ratatui::style::Style;
+use std::collections::HashMap;
+
+pub struct BrutjaTheme;
+
+impl BrutjaTheme {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Theme for BrutjaTheme {
+    fn info(&self) -> ThemeInfo {
+        let schema = HashMap::new();
+
+        ThemeInfo {
+            name: "Brutja".to_string(),
+            version: "1.0.0".to_string(),
+            author: "Benjamin Corey".to_string(),
+            description: "Somewhat brutalist theme".to_string(),
+            config_schema: schema,
+        }
+    }
+
+    fn templates(&self) -> HashMap<String, String> {
+        let mut templates = HashMap::new();
+
+        templates.insert(
+            "base.html".to_string(),
+            include_str!("templates/base.html").to_string(),
+        );
+        templates.insert(
+            "index.html".to_string(),
+            include_str!("templates/index.html").to_string(),
+        );
+        templates.insert(
+            "post.html".to_string(),
+            include_str!("templates/post.html").to_string(),
+        );
+        templates.insert(
+            "archive.html".to_string(),
+            include_str!("templates/archive.html").to_string(),
+        );
+        templates.insert(
+            "tag.html".to_string(),
+            include_str!("templates/tag.html").to_string(),
+        );
+        templates.insert(
+            "tags.html".to_string(),
+            include_str!("templates/tags.html").to_string(),
+        );
+
+        templates
+    }
+
+    fn assets(&self) -> HashMap<String, Vec<u8>> {
+        let mut assets = HashMap::new();
+
+        // Bundle a default Obsidian-compatible CSS
+        assets.insert(
+            "css/brutja-default.css".to_string(),
+            include_bytes!("assets/brutja-default.css").to_vec(),
+        );
+
+        assets
+    }
+
+    fn preview_tui_style(&self) -> Style {
+        use ratatui::style::Color;
+        Style::default()
+            .fg(Color::Rgb(167, 139, 250)) // Obsidian purple accent
+            .bg(Color::Rgb(32, 32, 32)) // Dark background similar to Obsidian
+    }
+}
+
+impl Default for BrutjaTheme {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/blogr-themes/src/brutja/mod.rs
+++ b/blogr-themes/src/brutja/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Theme, ThemeInfo};
+use crate::{Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::Style;
 use std::collections::HashMap;
 
@@ -24,39 +24,14 @@ impl Theme for BrutjaTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-        templates.insert(
-            "post_card.html".to_string(),
-            include_str!("templates/post_card.html").to_string(),
-        );
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-        templates.insert(
-            "post.html".to_string(),
-            include_str!("templates/post.html").to_string(),
-        );
-        templates.insert(
-            "archive.html".to_string(),
-            include_str!("templates/archive.html").to_string(),
-        );
-        templates.insert(
-            "tag.html".to_string(),
-            include_str!("templates/tag.html").to_string(),
-        );
-        templates.insert(
-            "tags.html".to_string(),
-            include_str!("templates/tags.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+            .with_template("post_card.html", include_str!("templates/post_card.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
+            .with_template("post.html", include_str!("templates/post.html"))
+            .with_template("archive.html", include_str!("templates/archive.html"))
+            .with_template("tag.html", include_str!("templates/tag.html"))
+            .with_template("tags.html", include_str!("templates/tags.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/brutja/mod.rs
+++ b/blogr-themes/src/brutja/mod.rs
@@ -32,6 +32,10 @@ impl Theme for BrutjaTheme {
             include_str!("templates/base.html").to_string(),
         );
         templates.insert(
+            "post_card.html".to_string(),
+            include_str!("templates/post_card.html").to_string(),
+        );
+        templates.insert(
             "index.html".to_string(),
             include_str!("templates/index.html").to_string(),
         );

--- a/blogr-themes/src/brutja/mod.rs
+++ b/blogr-themes/src/brutja/mod.rs
@@ -19,7 +19,7 @@ impl Theme for BrutjaTheme {
             name: "Brutja".to_string(),
             version: "1.0.0".to_string(),
             author: "Benjamin Corey".to_string(),
-            description: "Somewhat brutalist theme".to_string(),
+            description: "Brutalist, minimal theme with pops of color.".to_string(),
             config_schema: schema,
         }
     }

--- a/blogr-themes/src/brutja/mod.rs
+++ b/blogr-themes/src/brutja/mod.rs
@@ -25,7 +25,7 @@ impl Theme for BrutjaTheme {
     }
 
     fn templates(&self) -> ThemeTemplates {
-        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
             .with_template("post_card.html", include_str!("templates/post_card.html"))
             .with_template("index.html", include_str!("templates/index.html"))
             .with_template("post.html", include_str!("templates/post.html"))

--- a/blogr-themes/src/brutja/templates/archive.html
+++ b/blogr-themes/src/brutja/templates/archive.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "post_card.html" as post_card %}
 
 {% block title %}Archive - {{ site.blog.title }}{% endblock %}
 
@@ -21,37 +22,7 @@
             <h2 class="year-title">{{ year }}</h2>
             <div class="year-posts">
                 {% for post in year_posts %}
-                <article class="archive-post">
-                    <div class="post-date">
-                        <time datetime="{{ post.metadata.date }}">
-                            {{ post.metadata.date | date(format="%b %d") }}
-                        </time>
-                    </div>
-                    <div class="post-content">
-                        <h3 class="post-title">
-                            <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{
-                                post.metadata.title }}</a>
-                        </h3>
-                        {% if post.metadata.description %}
-                        <p class="post-description">{{ post.metadata.description }}</p>
-                        {% endif %}
-                        <div class="post-meta">
-                            {% if post.metadata.author %}
-                            <span class="post-author">by {{ post.metadata.author }}</span>
-                            {% endif %}
-                            {% if post.metadata.status == "draft" %}
-                            <span class="draft-badge">Draft</span>
-                            {% endif %}
-                        </div>
-                        {% if post.metadata.tags %}
-                        <div class="post-tags">
-                            {% for tag in post.metadata.tags %}
-                            <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">#{{ tag }}</a>
-                            {% endfor %}
-                        </div>
-                        {% endif %}
-                    </div>
-                </article>
+                {{ post_card::input(post=post) }}
                 {% endfor %}
             </div>
         </section>

--- a/blogr-themes/src/brutja/templates/archive.html
+++ b/blogr-themes/src/brutja/templates/archive.html
@@ -1,0 +1,102 @@
+{% extends "base.html" %}
+
+{% block title %}Archive - {{ site.blog.title }}{% endblock %}
+
+{% block meta %}
+<meta name="description" content="Archive of all posts from {{ site.blog.title }}">
+{% endblock %}
+
+{% block content %}
+<div class="archive-page">
+    <header class="archive-header">
+        <h1 class="archive-title">Archive</h1>
+        <p class="archive-subtitle">All posts from {{ site.blog.title }}</p>
+    </header>
+
+    {% if posts %}
+    <div class="archive-content">
+        {% if posts_by_year %}
+        {% for year, year_posts in posts_by_year %}
+        <section class="archive-year">
+            <h2 class="year-title">{{ year }}</h2>
+            <div class="year-posts">
+                {% for post in year_posts %}
+                <article class="archive-post">
+                    <div class="post-date">
+                        <time datetime="{{ post.metadata.date }}">
+                            {{ post.metadata.date | date(format="%b %d") }}
+                        </time>
+                    </div>
+                    <div class="post-content">
+                        <h3 class="post-title">
+                            <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{
+                                post.metadata.title }}</a>
+                        </h3>
+                        {% if post.metadata.description %}
+                        <p class="post-description">{{ post.metadata.description }}</p>
+                        {% endif %}
+                        <div class="post-meta">
+                            {% if post.metadata.author %}
+                            <span class="post-author">by {{ post.metadata.author }}</span>
+                            {% endif %}
+                            {% if post.metadata.status == "draft" %}
+                            <span class="draft-badge">Draft</span>
+                            {% endif %}
+                        </div>
+                        {% if post.metadata.tags %}
+                        <div class="post-tags">
+                            {% for tag in post.metadata.tags %}
+                            <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">#{{ tag }}</a>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+                    </div>
+                </article>
+                {% endfor %}
+            </div>
+        </section>
+        {% endfor %}
+        {% else %}
+        <div class="archive-posts">
+            {% for post in posts %}
+            <article class="archive-post">
+                <div class="post-date">
+                    <time datetime="{{ post.metadata.date }}">
+                        {{ post.metadata.date | date(format="%B %d, %Y") }}
+                    </time>
+                </div>
+                <div class="post-content">
+                    <h3 class="post-title">
+                        <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{ post.metadata.title
+                            }}</a>
+                    </h3>
+                    {% if post.metadata.description %}
+                    <p class="post-description">{{ post.metadata.description }}</p>
+                    {% endif %}
+                    <div class="post-meta">
+                        {% if post.metadata.author %}
+                        <span class="post-author">by {{ post.metadata.author }}</span>
+                        {% endif %}
+                        {% if post.metadata.status == "draft" %}
+                        <span class="draft-badge">Draft</span>
+                        {% endif %}
+                    </div>
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </div>
+    {% else %}
+    <div class="no-posts">
+        <p>No posts found in the archive.</p>
+        <p class="no-posts-hint">Posts will appear here once they are published.</p>
+    </div>
+    {% endif %}
+
+    <div class="archive-navigation">
+        <a href="{{ url(path='') | safe }}" class="back-home">← Home</a>
+        <a href="{{ url(path='tags/index.html') | safe }}" class="view-tags">View Tags →</a>
+    </div>
+</div>
+{% endblock %}

--- a/blogr-themes/src/brutja/templates/base.html
+++ b/blogr-themes/src/brutja/templates/base.html
@@ -15,7 +15,7 @@
     <meta name="author" content="{{ site.blog.author }}" />
     {% endblock %}
 
-    <!-- Load bundled default Obsidian CSS -->
+    <!-- Load bundled default brutja CSS -->
     <link rel="stylesheet" href="{{ url(path='css/brutja-default.css') | safe }}" />
 
     <meta name="blogr-base" content="{{ url(path='') | safe }}" />
@@ -61,34 +61,39 @@
 <body class="workspace-leaf-content">
     <div class="app-container">
         <div class="workspace">
-            <div class="workspace-split mod-vertical mod-root">
-                <div class="workspace-leaf mod-active">
-                    <div class="workspace-leaf-content">
-                        <!-- Search bar -->
-                        <div class="search-bar-container">
-                            <form id="search-form" class="search-form" role="search">
-                                <div class="search-container">
-                                    <input id="search-input" name="q" type="search" placeholder="Search posts..."
-                                        autocomplete="off" aria-label="Search posts" />
-                                    <button type="submit" class="search-button" aria-label="Search">
-                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
-                                            stroke="currentColor" stroke-width="2">
-                                            <circle cx="11" cy="11" r="8"></circle>
-                                            <path d="m21 21-4.35-4.35"></path>
-                                        </svg>
-                                    </button>
-                                </div>
-                                <div id="search-results" class="search-results" hidden></div>
-                            </form>
+            <div class="workspace-leaf-content">
+                <div class="center-column">
+                    <div class="navbar">
+                        <div class="navbar-link">
+                            <a href="{{ url(path='') | safe }}">Home</a>
                         </div>
-
-                        <div class="view-content" style="width: 100%; display: flex; justify-content: center;">
-                            <div class="markdown-reading-view"
-                                style="width: 100%; display: flex; justify-content: center;">
-                                <div class="markdown-preview-view markdown-rendered">
-                                    <div class="markdown-preview-section">
-                                        {% block content %}{% endblock %}
-                                    </div>
+                        {% if site.github_username %}
+                        <div class="navbar-link">
+                            <a href="{{ url(path='https://github.com/' ~ site.github_username) | safe }}">github</a>
+                        </div>
+                        {% endif %}
+                        <!-- Search bar -->
+                        <form id="search-form" class="search-form" role="search">
+                            <div class="search-container">
+                                <input id="search-input" name="q" type="search" placeholder="Search posts..."
+                                    autocomplete="off" aria-label="Search posts" />
+                                <button type="submit" class="search-button" aria-label="Search">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                        stroke-width="2">
+                                        <circle cx="11" cy="11" r="8"></circle>
+                                        <path d="m21 21-4.35-4.35"></path>
+                                    </svg>
+                                </button>
+                            </div>
+                            <div id="search-results" class="search-results" hidden></div>
+                        </form>
+                    </div>
+                    <!-- Page content -->
+                    <div class="view-content" style="width: 100%; display: flex; justify-content: center;">
+                        <div class="markdown-reading-view" style="width: 100%; display: flex; justify-content: center;">
+                            <div class="markdown-preview-view markdown-rendered">
+                                <div class="markdown-preview-section">
+                                    {% block content %}{% endblock %}
                                 </div>
                             </div>
                         </div>

--- a/blogr-themes/src/brutja/templates/base.html
+++ b/blogr-themes/src/brutja/templates/base.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% block title %}{{ site.blog.title }}{% endblock %}</title>
+
+    <!-- Favicon -->
+    <link rel="icon"
+        href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📝</text></svg>" />
+
+    {% block meta %}
+    <meta name="description" content="{{ site.blog.description }}" />
+    <meta name="author" content="{{ site.blog.author }}" />
+    {% endblock %}
+
+    <!-- Load bundled default Obsidian CSS -->
+    <link rel="stylesheet" href="{{ url(path='css/brutja-default.css') | safe }}" />
+
+    <meta name="blogr-base" content="{{ url(path='') | safe }}" />
+    {% block extra_head %}{% endblock %}
+
+    <script>
+        // Wait for DOM to be ready
+        document.addEventListener("DOMContentLoaded", function () {
+            var mode =
+                "{{ site.theme.config.color_mode | default(value='auto') }}";
+            var isDark =
+                window.matchMedia &&
+                window.matchMedia("(prefers-color-scheme: dark)").matches;
+            var body = document.body;
+
+            if (body) {
+                if (mode === "auto") {
+                    body.classList.toggle("theme-dark", isDark);
+                    body.classList.toggle("theme-light", !isDark);
+                } else {
+                    body.classList.add(
+                        mode === "dark" ? "theme-dark" : "theme-light",
+                    );
+                }
+
+                // Listen for system theme changes
+                if (mode === "auto" && window.matchMedia) {
+                    window
+                        .matchMedia("(prefers-color-scheme: dark)")
+                        .addEventListener("change", function (e) {
+                            body.classList.toggle("theme-dark", e.matches);
+                            body.classList.toggle(
+                                "theme-light",
+                                !e.matches,
+                            );
+                        });
+                }
+            }
+        });
+    </script>
+</head>
+
+<body class="workspace-leaf-content">
+    <div class="app-container">
+        <div class="workspace">
+            <div class="workspace-split mod-vertical mod-root">
+                <div class="workspace-leaf mod-active">
+                    <div class="workspace-leaf-content">
+                        <!-- Search bar -->
+                        <div class="search-bar-container">
+                            <form id="search-form" class="search-form" role="search">
+                                <div class="search-container">
+                                    <input id="search-input" name="q" type="search" placeholder="Search posts..."
+                                        autocomplete="off" aria-label="Search posts" />
+                                    <button type="submit" class="search-button" aria-label="Search">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                            stroke="currentColor" stroke-width="2">
+                                            <circle cx="11" cy="11" r="8"></circle>
+                                            <path d="m21 21-4.35-4.35"></path>
+                                        </svg>
+                                    </button>
+                                </div>
+                                <div id="search-results" class="search-results" hidden></div>
+                            </form>
+                        </div>
+
+                        <div class="view-content" style="width: 100%; display: flex; justify-content: center;">
+                            <div class="markdown-reading-view"
+                                style="width: 100%; display: flex; justify-content: center;">
+                                <div class="markdown-preview-view markdown-rendered">
+                                    <div class="markdown-preview-section">
+                                        {% block content %}{% endblock %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Search functionality -->
+    <script src="{{ url(path='js/vendor/minisearch.min.js') | safe }}"></script>
+    <script src="{{ url(path='js/search.js') | safe }}"></script>
+
+    {% block extra_scripts %}{% endblock %}
+</body>
+
+</html>

--- a/blogr-themes/src/brutja/templates/base.html
+++ b/blogr-themes/src/brutja/templates/base.html
@@ -18,6 +18,11 @@
     <!-- Load bundled default brutja CSS -->
     <link rel="stylesheet" href="{{ url(path='css/brutja-default.css') | safe }}" />
 
+    <!-- Load user-supplied custom CSS with error handling -->
+    <link rel="stylesheet" href="{{ url(path=site.theme.config.css | default(value='static/styles.css')) | safe }}"
+        onerror="this.onerror=null;console.warn('CSS not found - using default styles.');"
+        onload="console.log('CSS loaded successfully');" />
+
     <meta name="blogr-base" content="{{ url(path='') | safe }}" />
     {% block extra_head %}{% endblock %}
 
@@ -67,9 +72,16 @@
                         <div class="navbar-link">
                             <a href="{{ url(path='') | safe }}">Home</a>
                         </div>
-                        {% if site.github_username %}
+                        {% if site.theme.config.github_username %}
                         <div class="navbar-link">
-                            <a href="{{ url(path='https://github.com/' ~ site.github_username) | safe }}">github</a>
+                            <a
+                                href="{{ url(path='https://github.com/' ~ site.theme.config.github_username) | safe }}">github</a>
+                        </div>
+                        {% endif %}
+                        {% if site.theme.config.linkedin_username %}
+                        <div class="navbar-link">
+                            <a
+                                href="{{ url(path='https://linkedin.com/in/' ~ site.theme.config.linkedin_username) | safe }}">linkedin</a>
                         </div>
                         {% endif %}
                         <!-- Search bar -->

--- a/blogr-themes/src/brutja/templates/index.html
+++ b/blogr-themes/src/brutja/templates/index.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+
+{% block title %}{{ site.blog.title }} - Home{% endblock %}
+
+{% block content %}
+<div class="home-page">
+    <section class="hero-section">
+        <div class="hero-content">
+            <h2 class="hero-title">{{ site.blog.title }}</h2>
+            <p class="hero-description">{{ site.blog.description }}</p>
+        </div>
+    </section>
+
+    {% if posts %}
+    <section class="recent-posts">
+        <h4 class="section-title">Recent Posts</h4>
+        <div class="posts-grid">
+            {% for post in posts %}
+            <article class="post-card">
+                <div class="post-header">
+                    <h3 class="post-title">
+                        <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{ post.metadata.title
+                            }}</a>
+                    </h3>
+                    <div class="post-meta">
+                        <time class="post-date" datetime="{{ post.metadata.date }}">
+                            {{ post.metadata.date | date(format="%B %d, %Y") }}
+                        </time>
+                        {% if post.metadata.author %}
+                        <span class="post-author">by {{ post.metadata.author }}</span>
+                        {% endif %}
+                        {% if post.metadata.status == "draft" %}
+                        <span class="draft-badge">Draft</span>
+                        {% endif %}
+                    </div>
+                </div>
+
+                {% if post.metadata.description %}
+                <div class="post-excerpt">
+                    <p>{{ post.metadata.description }}</p>
+                </div>
+                {% endif %}
+
+                {% if post.metadata.tags %}
+                <div class="post-tags">
+                    {% for tag in post.metadata.tags %}
+                    <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">{{ tag }}</a>
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </article>
+            {% endfor %}
+        </div>
+
+        {% if has_more %}
+        <div class="view-more">
+            <a href="{{ url(path='archive.html') | safe }}" class="btn-view-more">View All Posts ({{ total_posts }}
+                total) →</a>
+        </div>
+        {% endif %}
+    </section>
+    {% else %}
+    <section class="no-posts">
+        <div class="empty-state">
+            <h3>No posts yet</h3>
+            <p>This blog is just getting started. Check back soon for new content!</p>
+        </div>
+    </section>
+    {% endif %}
+</div>
+{% endblock %}

--- a/blogr-themes/src/brutja/templates/index.html
+++ b/blogr-themes/src/brutja/templates/index.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
 {% import "post_card.html" as post_card %}
 
-{% block title %}{{ site.blog.title }} - Home{% endblock %}
-
 {% block content %}
 <div>
     <section class="hero-section">
         <div>
-            <h1 class="hero-title">{{ site.blog.title }}</h1>
+            <h1 class="hero-title">Benjamin Corey</h1>
+            <i>
+                <h3>Software developer in Philadelphia</h3>
+            </i>
             <p>{{ site.blog.description }}</p>
         </div>
     </section>

--- a/blogr-themes/src/brutja/templates/index.html
+++ b/blogr-themes/src/brutja/templates/index.html
@@ -5,9 +5,9 @@
 <div>
     <section class="hero-section">
         <div>
-            <h1 class="hero-title">Benjamin Corey</h1>
+            <h1 class="hero-title">{{ site.theme.config.hero_title | default(value='Welcome') }}</h1>
             <i>
-                <h3>Software developer in Philadelphia</h3>
+                <h3>{{ site.theme.config.hero_subtitle | default(value='Configure this theme in blogr.toml') }}</h3>
             </i>
             <p>{{ site.blog.description }}</p>
         </div>

--- a/blogr-themes/src/brutja/templates/index.html
+++ b/blogr-themes/src/brutja/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "post_card.html" as post_card %}
 
 {% block title %}{{ site.blog.title }} - Home{% endblock %}
 
@@ -16,39 +17,7 @@
         <h4 class="section-title">Recent Posts</h4>
         <div class="posts-grid">
             {% for post in posts %}
-            <article class="post-card">
-                <div class="post-header">
-                    <h3 class="post-title">
-                        <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{ post.metadata.title
-                            }}</a>
-                    </h3>
-                    <div class="post-meta">
-                        <time class="post-date" datetime="{{ post.metadata.date }}">
-                            {{ post.metadata.date | date(format="%B %d, %Y") }}
-                        </time>
-                        {% if post.metadata.author %}
-                        <span class="post-author">by {{ post.metadata.author }}</span>
-                        {% endif %}
-                        {% if post.metadata.status == "draft" %}
-                        <span class="draft-badge">Draft</span>
-                        {% endif %}
-                    </div>
-                </div>
-
-                {% if post.metadata.description %}
-                <div class="post-excerpt">
-                    <p>{{ post.metadata.description }}</p>
-                </div>
-                {% endif %}
-
-                {% if post.metadata.tags %}
-                <div class="post-tags">
-                    {% for tag in post.metadata.tags %}
-                    <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">#{{ tag }}</a>
-                    {% endfor %}
-                </div>
-                {% endif %}
-            </article>
+            {{ post_card::input(post=post) }}
             {% endfor %}
         </div>
 

--- a/blogr-themes/src/brutja/templates/index.html
+++ b/blogr-themes/src/brutja/templates/index.html
@@ -6,16 +6,16 @@
 {% block content %}
 <div>
     <section class="hero-section">
-        <div class="hero-content">
+        <div>
             <h1 class="hero-title">{{ site.blog.title }}</h1>
-            <p class="hero-description">{{ site.blog.description }}</p>
+            <p>{{ site.blog.description }}</p>
         </div>
     </section>
 
     {% if posts %}
-    <section class="recent-posts">
-        <h4 class="section-title">Recent Posts</h4>
-        <div class="posts-grid">
+    <section>
+        <h4>Recent Posts</h4>
+        <div>
             {% for post in posts %}
             {{ post_card::input(post=post) }}
             {% endfor %}
@@ -30,7 +30,7 @@
     </section>
     {% else %}
     <section class="no-posts">
-        <div class="empty-state">
+        <div>
             <h3>No posts yet</h3>
             <p>This blog is just getting started. Check back soon for new content!</p>
         </div>

--- a/blogr-themes/src/brutja/templates/index.html
+++ b/blogr-themes/src/brutja/templates/index.html
@@ -3,10 +3,10 @@
 {% block title %}{{ site.blog.title }} - Home{% endblock %}
 
 {% block content %}
-<div class="home-page">
+<div>
     <section class="hero-section">
         <div class="hero-content">
-            <h2 class="hero-title">{{ site.blog.title }}</h2>
+            <h1 class="hero-title">{{ site.blog.title }}</h1>
             <p class="hero-description">{{ site.blog.description }}</p>
         </div>
     </section>
@@ -44,7 +44,7 @@
                 {% if post.metadata.tags %}
                 <div class="post-tags">
                     {% for tag in post.metadata.tags %}
-                    <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">{{ tag }}</a>
+                    <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">#{{ tag }}</a>
                     {% endfor %}
                 </div>
                 {% endif %}

--- a/blogr-themes/src/brutja/templates/post.html
+++ b/blogr-themes/src/brutja/templates/post.html
@@ -3,7 +3,7 @@
 {% block content %}
 <article class="post-article">
     <header>
-        <h2 class="post-title">{{ post.metadata.title }}</h2>
+        <h1 class="post-title">{{ post.metadata.title }}</h1>
 
         <div class="post-meta">
             <time datetime="{{ post.metadata.date }}">

--- a/blogr-themes/src/brutja/templates/post.html
+++ b/blogr-themes/src/brutja/templates/post.html
@@ -1,28 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}{{ post.metadata.title }} - {{ site.blog.title }}{% endblock %}
-
-{% block meta %}
-<meta name="description" content="{{ post.metadata.description }}">
-<meta name="author" content="{{ post.metadata.author }}">
-{% endblock %}
-
 {% block content %}
 <article class="post-article">
-    <header class="post-header">
+    <header>
         <h2 class="post-title">{{ post.metadata.title }}</h2>
 
         <div class="post-meta">
-            <time class="post-date" datetime="{{ post.metadata.date }}">
+            <time datetime="{{ post.metadata.date }}">
                 {{ post.metadata.date | date(format="%B %d, %Y") }}
             </time>
 
             {% if post.metadata.author %}
-            <span class="post-author">by {{ post.metadata.author }}</span>
-            {% endif %}
-
-            {% if reading_time %}
-            <span class="reading-time">{{ reading_time }} min read</span>
+            <span>by {{ post.metadata.author }}</span>
             {% endif %}
 
             {% if post.metadata.status == "draft" %}

--- a/blogr-themes/src/brutja/templates/post.html
+++ b/blogr-themes/src/brutja/templates/post.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}{{ post.metadata.title }} - {{ site.blog.title }}{% endblock %}
+
+{% block meta %}
+<meta name="description" content="{{ post.metadata.description }}">
+<meta name="author" content="{{ post.metadata.author }}">
+{% endblock %}
+
+{% block content %}
+<article class="post-article">
+    <header class="post-header">
+        <h2 class="post-title">{{ post.metadata.title }}</h2>
+
+        <div class="post-meta">
+            <time class="post-date" datetime="{{ post.metadata.date }}">
+                {{ post.metadata.date | date(format="%B %d, %Y") }}
+            </time>
+
+            {% if post.metadata.author %}
+            <span class="post-author">by {{ post.metadata.author }}</span>
+            {% endif %}
+
+            {% if reading_time %}
+            <span class="reading-time">{{ reading_time }} min read</span>
+            {% endif %}
+
+            {% if post.metadata.status == "draft" %}
+            <span class="draft-badge">Draft</span>
+            {% endif %}
+        </div>
+
+        {% if post.metadata.tags %}
+        <div class="post-tags">
+            {% for tag in post.metadata.tags %}
+            <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">#{{ tag }}</a>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </header>
+
+    <div class="post-content">
+        {{ content | safe }}
+    </div>
+
+    <footer class="post-footer">
+        <div class="post-navigation">
+            <a href="{{ url(path='') | safe }}" class="back-home">← Home</a>
+            <a href="{{ url(path='archive.html') | safe }}" class="view-archive">Archive →</a>
+        </div>
+    </footer>
+</article>
+{% endblock %}

--- a/blogr-themes/src/brutja/templates/post_card.html
+++ b/blogr-themes/src/brutja/templates/post_card.html
@@ -1,16 +1,16 @@
 {% macro input(post) %}
 <article class="post-card">
-    <div class="post-header">
+    <div>
         <h3 class="post-title">
             <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{ post.metadata.title
                 }}</a>
         </h3>
         <div class="post-meta">
-            <time class="post-date" datetime="{{ post.metadata.date }}">
+            <time datetime="{{ post.metadata.date }}">
                 {{ post.metadata.date | date(format="%B %d, %Y") }}
             </time>
             {% if post.metadata.author %}
-            <span class="post-author">by {{ post.metadata.author }}</span>
+            <span>by {{ post.metadata.author }}</span>
             {% endif %}
             {% if post.metadata.status == "draft" %}
             <span class="draft-badge">Draft</span>

--- a/blogr-themes/src/brutja/templates/post_card.html
+++ b/blogr-themes/src/brutja/templates/post_card.html
@@ -1,10 +1,10 @@
 {% macro input(post) %}
 <article class="post-card">
     <div>
-        <h3 class="post-title">
+        <h2 class="post-title">
             <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{ post.metadata.title
                 }}</a>
-        </h3>
+        </h2>
         <div class="post-meta">
             <time datetime="{{ post.metadata.date }}">
                 {{ post.metadata.date | date(format="%B %d, %Y") }}

--- a/blogr-themes/src/brutja/templates/post_card.html
+++ b/blogr-themes/src/brutja/templates/post_card.html
@@ -1,0 +1,35 @@
+{% macro input(post) %}
+<article class="post-card">
+    <div class="post-header">
+        <h3 class="post-title">
+            <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{ post.metadata.title
+                }}</a>
+        </h3>
+        <div class="post-meta">
+            <time class="post-date" datetime="{{ post.metadata.date }}">
+                {{ post.metadata.date | date(format="%B %d, %Y") }}
+            </time>
+            {% if post.metadata.author %}
+            <span class="post-author">by {{ post.metadata.author }}</span>
+            {% endif %}
+            {% if post.metadata.status == "draft" %}
+            <span class="draft-badge">Draft</span>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if post.metadata.description %}
+    <div class="post-excerpt">
+        <p>{{ post.metadata.description }}</p>
+    </div>
+    {% endif %}
+
+    {% if post.metadata.tags %}
+    <div class="post-tags">
+        {% for tag in post.metadata.tags %}
+        <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">#{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>
+{% endmacro input %}

--- a/blogr-themes/src/brutja/templates/tag.html
+++ b/blogr-themes/src/brutja/templates/tag.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "post_card.html" as post_card %}
 {% block title %}{{ tag }} - {{ site.blog.title }}{% endblock %}
 {% block meta %}
 <meta name="description" content="Posts exploring {{ tag }} on {{ site.blog.title }}" />
@@ -28,39 +29,7 @@
 
         <div class="search-result-container">
             {% for post in posts %}
-            <article class="post-card">
-                <div class="post-header">
-                    <h3 class="post-title">
-                        <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{ post.metadata.title
-                            }}</a>
-                    </h3>
-                    <div class="post-meta">
-                        <time class="post-date" datetime="{{ post.metadata.date }}">
-                            {{ post.metadata.date | date(format="%B %d, %Y") }}
-                        </time>
-                        {% if post.metadata.author %}
-                        <span class="post-author">by {{ post.metadata.author }}</span>
-                        {% endif %}
-                        {% if post.metadata.status == "draft" %}
-                        <span class="draft-badge">Draft</span>
-                        {% endif %}
-                    </div>
-                </div>
-
-                {% if post.metadata.description %}
-                <div class="post-excerpt">
-                    <p>{{ post.metadata.description }}</p>
-                </div>
-                {% endif %}
-
-                {% if post.metadata.tags %}
-                <div class="post-tags">
-                    {% for tag in post.metadata.tags %}
-                    <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">#{{ tag }}</a>
-                    {% endfor %}
-                </div>
-                {% endif %}
-            </article>
+            {{ post_card::input(post=post) }}
             {% endfor %}
         </div>
     </div>

--- a/blogr-themes/src/brutja/templates/tag.html
+++ b/blogr-themes/src/brutja/templates/tag.html
@@ -1,0 +1,109 @@
+{% extends "base.html" %}
+{% block title %}{{ tag }} - {{ site.blog.title }}{% endblock %}
+{% block meta %}
+<meta name="description" content="Posts exploring {{ tag }} on {{ site.blog.title }}" />
+{% endblock %}
+{% block content %}
+<div class="markdown-preview-sizer markdown-preview-section">
+    <div class="inline-title" contenteditable="false" spellcheck="false" tabindex="-1" enterkeyhint="done">
+        #{{ tag }}
+    </div>
+
+    <div class="callout" data-callout="note">
+        <div class="callout-title">
+            <div class="callout-icon">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+                    <line x1="7" y1="7" x2="7.01" y2="7" />
+                </svg>
+            </div>
+            <div class="callout-title-inner">Tagged Posts</div>
+        </div>
+        <div class="callout-content">
+            <p>All posts tagged with <span class="tag">#{{ tag }}</span></p>
+        </div>
+    </div>
+
+    <!-- Backlinks section in Obsidian style -->
+    <div class="backlink-pane">
+        <div class="tree-item-self nav-folder-title">
+            <div class="tree-item-inner nav-folder-title-content">
+                Linked Mentions
+                <span class="tree-item-flair">{{ posts | length }}</span>
+            </div>
+        </div>
+
+        <div class="search-result-container">
+            {% for post in posts %}
+            <div class="search-result-file-matches">
+                <div class="search-result-file-title">
+                    <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') }}" class="internal-link">
+                        {{ post.metadata.title }}
+                    </a>
+                </div>
+
+                <div class="search-result-file-match">
+                    <!-- Post metadata -->
+                    <div class="search-result-file-match-content">
+                        <div class="frontmatter-section-simple">
+                            <span class="frontmatter-alias">
+                                <span class="frontmatter-alias-icon">📅</span>
+                                <time datetime="{{ post.metadata.date }}">{{ post.metadata.date }}</time>
+                            </span>
+                            {% if post.metadata.author %}
+                            <span class="frontmatter-alias">
+                                <span class="frontmatter-alias-icon">👤</span>
+                                <span>{{ post.metadata.author }}</span>
+                            </span>
+                            {% endif %}
+                        </div>
+
+                        <!-- Post description if available -->
+                        {% if post.metadata.description %}
+                        <blockquote class="search-excerpt">
+                            {{ post.metadata.description }}
+                        </blockquote>
+                        {% endif %}
+
+                        <!-- Other tags from this post -->
+                        {% if post.metadata.tags %}
+                        <div class="post-tags">
+                            {% for post_tag in post.metadata.tags %} {% if
+                            post_tag != tag %}
+                            <a href="{{ url(path='tags/' ~ post_tag ~ '.html') }}" class="tag">
+                                <span class="tag-name">#{{ post_tag }}</span>
+                            </a>
+                            {% endif %} {% endfor %}
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+
+    {% if posts | length == 0 %}
+    <!-- No posts with this tag -->
+    <div class="callout" data-callout="warning">
+        <div class="callout-content">
+            <p>
+                No posts found with the tag <span class="tag">#{{ tag }}</span>.
+            </p>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Navigation callout -->
+    <div class="callout" data-callout="tip">
+        <div class="callout-content">
+            <p>
+                Browse all
+                <a href="{{ url(path='tags/') }}" class="internal-link">tags</a>, view the
+                <a href="{{ url(path='archive.html') }}" class="internal-link">archive</a>, or return to
+                <a href="{{ url(path='') }}" class="internal-link">home</a>.
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/blogr-themes/src/brutja/templates/tag.html
+++ b/blogr-themes/src/brutja/templates/tag.html
@@ -24,61 +24,43 @@
         </div>
     </div>
 
-    <!-- Backlinks section in Obsidian style -->
     <div class="backlink-pane">
-        <div class="tree-item-self nav-folder-title">
-            <div class="tree-item-inner nav-folder-title-content">
-                Linked Mentions
-                <span class="tree-item-flair">{{ posts | length }}</span>
-            </div>
-        </div>
 
         <div class="search-result-container">
             {% for post in posts %}
-            <div class="search-result-file-matches">
-                <div class="search-result-file-title">
-                    <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') }}" class="internal-link">
-                        {{ post.metadata.title }}
-                    </a>
-                </div>
-
-                <div class="search-result-file-match">
-                    <!-- Post metadata -->
-                    <div class="search-result-file-match-content">
-                        <div class="frontmatter-section-simple">
-                            <span class="frontmatter-alias">
-                                <span class="frontmatter-alias-icon">📅</span>
-                                <time datetime="{{ post.metadata.date }}">{{ post.metadata.date }}</time>
-                            </span>
-                            {% if post.metadata.author %}
-                            <span class="frontmatter-alias">
-                                <span class="frontmatter-alias-icon">👤</span>
-                                <span>{{ post.metadata.author }}</span>
-                            </span>
-                            {% endif %}
-                        </div>
-
-                        <!-- Post description if available -->
-                        {% if post.metadata.description %}
-                        <blockquote class="search-excerpt">
-                            {{ post.metadata.description }}
-                        </blockquote>
+            <article class="post-card">
+                <div class="post-header">
+                    <h3 class="post-title">
+                        <a href="{{ url(path='posts/' ~ post.metadata.slug ~ '.html') | safe }}">{{ post.metadata.title
+                            }}</a>
+                    </h3>
+                    <div class="post-meta">
+                        <time class="post-date" datetime="{{ post.metadata.date }}">
+                            {{ post.metadata.date | date(format="%B %d, %Y") }}
+                        </time>
+                        {% if post.metadata.author %}
+                        <span class="post-author">by {{ post.metadata.author }}</span>
                         {% endif %}
-
-                        <!-- Other tags from this post -->
-                        {% if post.metadata.tags %}
-                        <div class="post-tags">
-                            {% for post_tag in post.metadata.tags %} {% if
-                            post_tag != tag %}
-                            <a href="{{ url(path='tags/' ~ post_tag ~ '.html') }}" class="tag">
-                                <span class="tag-name">#{{ post_tag }}</span>
-                            </a>
-                            {% endif %} {% endfor %}
-                        </div>
+                        {% if post.metadata.status == "draft" %}
+                        <span class="draft-badge">Draft</span>
                         {% endif %}
                     </div>
                 </div>
-            </div>
+
+                {% if post.metadata.description %}
+                <div class="post-excerpt">
+                    <p>{{ post.metadata.description }}</p>
+                </div>
+                {% endif %}
+
+                {% if post.metadata.tags %}
+                <div class="post-tags">
+                    {% for tag in post.metadata.tags %}
+                    <a href="{{ url(path='tags/' ~ tag ~ '.html') | safe }}" class="tag">#{{ tag }}</a>
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </article>
             {% endfor %}
         </div>
     </div>

--- a/blogr-themes/src/brutja/templates/tag.html
+++ b/blogr-themes/src/brutja/templates/tag.html
@@ -10,21 +10,6 @@
         #{{ tag }}
     </div>
 
-    <div class="callout" data-callout="note">
-        <div class="callout-title">
-            <div class="callout-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
-                    <line x1="7" y1="7" x2="7.01" y2="7" />
-                </svg>
-            </div>
-            <div class="callout-title-inner">Tagged Posts</div>
-        </div>
-        <div class="callout-content">
-            <p>All posts tagged with <span class="tag">#{{ tag }}</span></p>
-        </div>
-    </div>
-
     <div class="backlink-pane">
 
         <div class="search-result-container">

--- a/blogr-themes/src/brutja/templates/tags.html
+++ b/blogr-themes/src/brutja/templates/tags.html
@@ -14,7 +14,7 @@
         <div class="post-tags">
             {% for tag_info in tags %}
             <a href="{{ url(path='tags/' ~ tag_info.0 ~ '.html') }}" class="tag" data-tag-name="{{ tag_info.0 }}">
-                <span class="tag-name">{{ tag_info.0 }} ({{tag_info.1}})</span>
+                <span class="tag-name">#{{ tag_info.0 }} ({{tag_info.1}})</span>
             </a>
             {% endfor %}
         </div>

--- a/blogr-themes/src/brutja/templates/tags.html
+++ b/blogr-themes/src/brutja/templates/tags.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+{% block title %}Tags - {{ site.blog.title }}{% endblock %}
+{% block meta %}
+<meta name="description" content="Browse all tags on {{ site.blog.title }}" />
+{% endblock %}
+{% block content %}
+<div class="markdown-preview-sizer markdown-preview-section">
+    <div class="inline-title" contenteditable="false" spellcheck="false" tabindex="-1" enterkeyhint="done">
+        Tags
+    </div>
+
+    {% if tags %}
+    <div class="tag-pane">
+        <div class="post-tags">
+            {% for tag_info in tags %}
+            <a href="{{ url(path='tags/' ~ tag_info.0 ~ '.html') }}" class="tag" data-tag-name="{{ tag_info.0 }}">
+                <span class="tag-name">{{ tag_info.0 }} ({{tag_info.1}})</span>
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+
+    <!-- Tag statistics -->
+    <div class="search-result-container">
+        <div class="search-result-file-title">
+            <span class="search-result-count">{{ tags | length }} unique tags across all posts</span>
+        </div>
+
+        <div class="search-result-file-matches">
+            {% for tag_info in tags %}
+            <div class="search-result-file-match">
+                <div class="search-result-file-title">
+                    <a href="{{ url(path='tags/' ~ tag_info.0 ~ '.html') }}" class="internal-link">
+                        #{{ tag_info.0 }}
+                    </a>
+                </div>
+                <div class="search-result-file-match-content">
+                    {{ tag_info.1 }} post{% if tag_info.1 != 1 %}s{% endif
+                    %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+
+    {% else %}
+    <!-- No tags state -->
+    <div class="callout" data-callout="warning">
+        <div class="callout-title">
+            <div class="callout-icon">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path
+                        d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                    <line x1="12" y1="9" x2="12" y2="13" />
+                    <line x1="12" y1="17" x2="12.01" y2="17" />
+                </svg>
+            </div>
+            <div class="callout-title-inner">No Tags Found</div>
+        </div>
+        <div class="callout-content">
+            <p>
+                No tags have been added to posts yet. Tags will appear here
+                once you start adding them to your content.
+            </p>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Navigation callout -->
+    <div class="callout" data-callout="tip">
+        <div class="callout-content">
+            <p>
+                View the complete
+                <a href="{{ url(path='archive.html') }}" class="internal-link">archive</a>
+                or return to
+                <a href="{{ url(path='') }}" class="internal-link">home</a>.
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/blogr-themes/src/dark_minimal/mod.rs
+++ b/blogr-themes/src/dark_minimal/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -116,20 +116,9 @@ impl Theme for DarkMinimalTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/lib.rs
+++ b/blogr-themes/src/lib.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub mod dark_minimal;
+pub mod brutja;
 pub mod minimal_retro;
 pub mod musashi;
 pub mod obsidian;
@@ -10,6 +11,7 @@ pub mod terminal_candy;
 pub mod typewriter;
 
 pub use dark_minimal::DarkMinimalTheme;
+pub use brutja::BrutjaTheme;
 pub use minimal_retro::MinimalRetroTheme;
 pub use musashi::MusashiTheme;
 pub use obsidian::ObsidianTheme;
@@ -91,6 +93,9 @@ pub fn get_all_themes() -> HashMap<String, Box<dyn Theme>> {
 
     let typewriter = TypewriterTheme::new();
     themes.insert("typewriter".to_string(), Box::new(typewriter));
+    
+    let brutja = BrutjaTheme::new();
+    themes.insert("brutja".to_string(), Box::new(brutja));
 
     themes
 }
@@ -105,6 +110,7 @@ pub fn get_theme(name: &str) -> Option<Box<dyn Theme>> {
         "musashi" => Some(Box::new(MusashiTheme::new()) as Box<dyn Theme>),
         "slate-portfolio" => Some(Box::new(SlatePortfolioTheme::new()) as Box<dyn Theme>),
         "typewriter" => Some(Box::new(TypewriterTheme::new()) as Box<dyn Theme>),
+        "brutja" => Some(Box::new(BrutjaTheme::new()) as Box<dyn Theme>),
         _ => None,
     }
 }

--- a/blogr-themes/src/lib.rs
+++ b/blogr-themes/src/lib.rs
@@ -35,9 +35,36 @@ pub struct ConfigOption {
 
 pub trait Theme: Send + Sync {
     fn info(&self) -> ThemeInfo;
-    fn templates(&self) -> HashMap<String, String>;
+    fn templates(&self) -> ThemeTemplates;
     fn assets(&self) -> HashMap<String, Vec<u8>>;
     fn preview_tui_style(&self) -> ratatui::style::Style;
+}
+
+pub struct ThemeTemplates {
+    templates: Vec<(&'static str, &'static str)>,
+}
+
+impl ThemeTemplates {
+    // Base template must be first. This ensure it's registered first with Tera when we iterate through the templates.
+    pub fn new(base_template_name: &'static str, base_template: &'static str) -> Self {
+        Self {
+            templates: vec![(base_template_name, base_template)],
+        }
+    }
+
+    pub fn with_template(mut self, name: &'static str, template: &'static str) -> Self {
+        self.templates.push((name, template));
+        self
+    }
+}
+
+impl IntoIterator for ThemeTemplates {
+    type Item = (&'static str, &'static str);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.templates.into_iter()
+    }
 }
 
 #[must_use]

--- a/blogr-themes/src/minimal_retro/mod.rs
+++ b/blogr-themes/src/minimal_retro/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -96,46 +96,13 @@ impl Theme for MinimalRetroTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        // Base layout template
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        // Index/home page template
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        // Individual post template
-        templates.insert(
-            "post.html".to_string(),
-            include_str!("templates/post.html").to_string(),
-        );
-
-        // Archive/list template
-        templates.insert(
-            "archive.html".to_string(),
-            include_str!("templates/archive.html").to_string(),
-        );
-
-        // Tag page template
-        templates.insert(
-            "tag.html".to_string(),
-            include_str!("templates/tag.html").to_string(),
-        );
-
-        // Tags index template
-        templates.insert(
-            "tags.html".to_string(),
-            include_str!("templates/tags.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
+            .with_template("post.html", include_str!("templates/post.html"))
+            .with_template("archive.html", include_str!("templates/archive.html"))
+            .with_template("tag.html", include_str!("templates/tag.html"))
+            .with_template("tags.html", include_str!("templates/tags.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/minimal_retro/mod.rs
+++ b/blogr-themes/src/minimal_retro/mod.rs
@@ -97,7 +97,7 @@ impl Theme for MinimalRetroTheme {
     }
 
     fn templates(&self) -> ThemeTemplates {
-        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
             .with_template("index.html", include_str!("templates/index.html"))
             .with_template("post.html", include_str!("templates/post.html"))
             .with_template("archive.html", include_str!("templates/archive.html"))

--- a/blogr-themes/src/musashi/mod.rs
+++ b/blogr-themes/src/musashi/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -105,20 +105,9 @@ impl Theme for MusashiTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/obsidian/mod.rs
+++ b/blogr-themes/src/obsidian/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::Style;
 use std::collections::HashMap;
 
@@ -42,35 +42,13 @@ impl Theme for ObsidianTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-        templates.insert(
-            "post.html".to_string(),
-            include_str!("templates/post.html").to_string(),
-        );
-        templates.insert(
-            "archive.html".to_string(),
-            include_str!("templates/archive.html").to_string(),
-        );
-        templates.insert(
-            "tag.html".to_string(),
-            include_str!("templates/tag.html").to_string(),
-        );
-        templates.insert(
-            "tags.html".to_string(),
-            include_str!("templates/tags.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
+            .with_template("post.html", include_str!("templates/post.html"))
+            .with_template("archive.html", include_str!("templates/archive.html"))
+            .with_template("tag.html", include_str!("templates/tag.html"))
+            .with_template("tags.html", include_str!("templates/tags.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/obsidian/mod.rs
+++ b/blogr-themes/src/obsidian/mod.rs
@@ -43,7 +43,7 @@ impl Theme for ObsidianTheme {
     }
 
     fn templates(&self) -> ThemeTemplates {
-        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
             .with_template("index.html", include_str!("templates/index.html"))
             .with_template("post.html", include_str!("templates/post.html"))
             .with_template("archive.html", include_str!("templates/archive.html"))

--- a/blogr-themes/src/slate_portfolio/mod.rs
+++ b/blogr-themes/src/slate_portfolio/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -107,20 +107,9 @@ impl Theme for SlatePortfolioTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/terminal_candy/mod.rs
+++ b/blogr-themes/src/terminal_candy/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -105,40 +105,13 @@ impl Theme for TerminalCandyTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates.insert(
-            "post.html".to_string(),
-            include_str!("templates/post.html").to_string(),
-        );
-
-        templates.insert(
-            "archive.html".to_string(),
-            include_str!("templates/archive.html").to_string(),
-        );
-
-        templates.insert(
-            "tag.html".to_string(),
-            include_str!("templates/tag.html").to_string(),
-        );
-
-        templates.insert(
-            "tags.html".to_string(),
-            include_str!("templates/tags.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
+            .with_template("post.html", include_str!("templates/post.html"))
+            .with_template("archive.html", include_str!("templates/archive.html"))
+            .with_template("tag.html", include_str!("templates/tag.html"))
+            .with_template("tags.html", include_str!("templates/tags.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {

--- a/blogr-themes/src/terminal_candy/mod.rs
+++ b/blogr-themes/src/terminal_candy/mod.rs
@@ -106,7 +106,7 @@ impl Theme for TerminalCandyTheme {
     }
 
     fn templates(&self) -> ThemeTemplates {
-        ThemeTemplates::new("base_html", include_str!("templates/base.html"))
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
             .with_template("index.html", include_str!("templates/index.html"))
             .with_template("post.html", include_str!("templates/post.html"))
             .with_template("archive.html", include_str!("templates/archive.html"))

--- a/blogr-themes/src/typewriter/mod.rs
+++ b/blogr-themes/src/typewriter/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo};
+use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -96,20 +96,9 @@ impl Theme for TypewriterTheme {
         }
     }
 
-    fn templates(&self) -> HashMap<String, String> {
-        let mut templates = HashMap::new();
-
-        templates.insert(
-            "base.html".to_string(),
-            include_str!("templates/base.html").to_string(),
-        );
-
-        templates.insert(
-            "index.html".to_string(),
-            include_str!("templates/index.html").to_string(),
-        );
-
-        templates
+    fn templates(&self) -> ThemeTemplates {
+        ThemeTemplates::new("base.html", include_str!("templates/base.html"))
+            .with_template("index.html", include_str!("templates/index.html"))
     }
 
     fn assets(&self) -> HashMap<String, Vec<u8>> {


### PR DESCRIPTION
Depends on #24 . is a draft until that's merged. Open to comment in the meantime.

Minimal, brutalist blog theme. Currently set up to use custom CSS to set the variables that dictate the color scheme. I see that the Typewriter theme uses an array of config options instead for similar functionality, which might be a better way to handle this - I need to look into that further.

__TODO__
- better mobile support
- finalize config API

__LATER__
- support for profile image(s) on the homepage
- newsletter registration

__THEME QUESTIONS__
- Best practices for documenting theme APIs?
    - `blogr theme list` is very crowded.
    - the blogr README is also getting very long.
- switching themes isn't super simple when the config for each varies so widely. Is there some way we could auto-update blogr.toml with the new default theme config when the theme is switched?

__DEMO__

https://github.com/user-attachments/assets/1ec61c49-29ef-4742-a580-ab04f8f7de11



__HOME PAGE__
<img width="1470" height="774" alt="Screenshot 2025-10-05 at 10 02 42 PM" src="https://github.com/user-attachments/assets/973855f7-bcaf-4dae-8fe0-bc17ce0235f0" />
__POST VIEW__
<img width="1470" height="774" alt="Screenshot 2025-10-05 at 10 02 51 PM" src="https://github.com/user-attachments/assets/87cb89a2-c922-4a35-aed4-620a75e403b4" />
__CUSTOMIZATION__
<img width="1470" height="774" alt="Screenshot 2025-10-05 at 10 01 01 PM" src="https://github.com/user-attachments/assets/2c2c2889-536f-47f2-bbdb-ace2f37791f6" />
<img width="1470" height="774" alt="Screenshot 2025-10-05 at 9 42 13 PM" src="https://github.com/user-attachments/assets/0851710a-b523-4a63-aa8f-46a0c808d8f1" />
