### PR TITLE
Fix: Theme Compatibility Validation for Blog and Personal Sites

### DIFF
--- a/blogr-cli/src/commands/theme.rs
+++ b/blogr-cli/src/commands/theme.rs
@@ -31,7 +31,7 @@ pub async fn handle_list() -> Result<()> {
 
         for (name, theme) in all_themes {
             let info = theme.info();
-            if info.site_type == "blog" {
+            if info.site_type.to_string() == "blog" {
                 blog_themes.push((name, info));
             } else {
                 personal_themes.push((name, info));
@@ -150,9 +150,23 @@ pub async fn handle_set(name: String) -> Result<()> {
     let theme_info = theme.info();
     let site_type = &config.site.site_type;
 
-    if theme_info.site_type != *site_type {
-        let blog_themes = "minimal-retro, obsidian, terminal-candy";
-        let personal_themes = "dark-minimal, musashi, slate-portfolio, typewriter";
+    if theme_info.site_type.to_string() != *site_type {
+        // Dynamically build theme lists by site type
+        let all_themes = get_all_themes();
+        let mut blog_theme_names = Vec::new();
+        let mut personal_theme_names = Vec::new();
+
+        for (theme_name, theme_obj) in all_themes {
+            let info = theme_obj.info();
+            if info.site_type.to_string() == "blog" {
+                blog_theme_names.push(theme_name);
+            } else {
+                personal_theme_names.push(theme_name);
+            }
+        }
+
+        let blog_themes = blog_theme_names.join(", ");
+        let personal_themes = personal_theme_names.join(", ");
 
         return Err(anyhow!(
             "❌ Theme '{}' is a {} theme, but your site is configured as a {} site.\n\n\

--- a/blogr-themes/src/dark_minimal/mod.rs
+++ b/blogr-themes/src/dark_minimal/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
+use crate::{ConfigOption, SiteType, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -113,7 +113,7 @@ impl Theme for DarkMinimalTheme {
             author: "Blogr Team".to_string(),
             description: "A dark, minimal theme for personal websites with quirky interactions and clean aesthetics.".to_string(),
             config_schema,
-            site_type: "personal".to_string(),
+            site_type: SiteType::Personal,
         }
     }
 

--- a/blogr-themes/src/lib.rs
+++ b/blogr-themes/src/lib.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt;
 
 pub mod dark_minimal;
 pub mod minimal_retro;
@@ -17,6 +18,21 @@ pub use slate_portfolio::SlatePortfolioTheme;
 pub use terminal_candy::TerminalCandyTheme;
 pub use typewriter::TypewriterTheme;
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum SiteType {
+    Blog,
+    Personal,
+}
+
+impl fmt::Display for SiteType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SiteType::Blog => write!(f, "blog"),
+            SiteType::Personal => write!(f, "personal"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThemeInfo {
     pub name: String,
@@ -24,8 +40,8 @@ pub struct ThemeInfo {
     pub author: String,
     pub description: String,
     pub config_schema: HashMap<String, ConfigOption>,
-    /// Type of site this theme supports: "blog" or "personal"
-    pub site_type: String,
+    /// Type of site this theme supports
+    pub site_type: SiteType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/blogr-themes/src/minimal_retro/mod.rs
+++ b/blogr-themes/src/minimal_retro/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
+use crate::{ConfigOption, SiteType, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -93,7 +93,7 @@ impl Theme for MinimalRetroTheme {
             author: "Blogr Team".to_string(),
             description: "An artistic, minimal theme focused on content with expandable posts and beautiful typography".to_string(),
             config_schema,
-            site_type: "blog".to_string(),
+            site_type: SiteType::Blog,
         }
     }
 

--- a/blogr-themes/src/musashi/mod.rs
+++ b/blogr-themes/src/musashi/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
+use crate::{ConfigOption, SiteType, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -102,7 +102,7 @@ impl Theme for MusashiTheme {
             author: "Blogr Team".to_string(),
             description: "An elegant monochrome theme inspired by sumi-e ink wash painting. Soft whites, warm grays, and ink blacks. Peaceful, refined, embodying the warrior's disciplined way. Fully customizable from content.md.".to_string(),
             config_schema,
-            site_type: "personal".to_string(),
+            site_type: SiteType::Personal,
         }
     }
 

--- a/blogr-themes/src/obsidian/mod.rs
+++ b/blogr-themes/src/obsidian/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
+use crate::{ConfigOption, SiteType, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::Style;
 use std::collections::HashMap;
 
@@ -39,7 +39,7 @@ impl Theme for ObsidianTheme {
             author: "Blogr Team".to_string(),
             description: "Adopts Obsidian community themes to style Blogr content".to_string(),
             config_schema: schema,
-            site_type: "blog".to_string(),
+            site_type: SiteType::Blog,
         }
     }
 

--- a/blogr-themes/src/slate_portfolio/mod.rs
+++ b/blogr-themes/src/slate_portfolio/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
+use crate::{ConfigOption, SiteType, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -104,7 +104,7 @@ impl Theme for SlatePortfolioTheme {
             author: "Blogr Team".to_string(),
             description: "A sleek, modern dark portfolio theme with polished aesthetics and smooth interactions.".to_string(),
             config_schema,
-            site_type: "personal".to_string(),
+            site_type: SiteType::Personal,
         }
     }
 

--- a/blogr-themes/src/terminal_candy/mod.rs
+++ b/blogr-themes/src/terminal_candy/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
+use crate::{ConfigOption, SiteType, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -102,7 +102,7 @@ impl Theme for TerminalCandyTheme {
             author: "Blogr Team".to_string(),
             description: "A quirky terminal-inspired theme with pastel colors, glitch effects, and playful animations. Perfect for personal websites.".to_string(),
             config_schema,
-            site_type: "blog".to_string(),
+            site_type: SiteType::Blog,
         }
     }
 

--- a/blogr-themes/src/typewriter/mod.rs
+++ b/blogr-themes/src/typewriter/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ConfigOption, Theme, ThemeInfo, ThemeTemplates};
+use crate::{ConfigOption, SiteType, Theme, ThemeInfo, ThemeTemplates};
 use ratatui::style::{Color, Style};
 use std::collections::HashMap;
 
@@ -93,7 +93,7 @@ impl Theme for TypewriterTheme {
             author: "Blogr Team".to_string(),
             description: "A vintage typewriter-inspired theme with nostalgic aesthetics and mechanical charm.".to_string(),
             config_schema,
-            site_type: "personal".to_string(),
+            site_type: SiteType::Personal,
         }
     }
 


### PR DESCRIPTION
## Fixes
Closes #19

## Problem
Users could set incompatible themes (e.g., blog themes on personal sites), causing the serve/build commands to fail with:
```
Error: Failed to render personal index template
```

This occurred because blog themes require templates like `post.html`, `archive.html`, etc., which personal sites don't use, and vice versa.

## Solution
This PR adds theme type validation to prevent incompatible themes from being set, providing clear error messages and guidance when users attempt to use an incompatible theme.

## Changes

### 1. **Theme Type Classification** (`blogr-themes/src/lib.rs`)
- Added `site_type: String` field to `ThemeInfo` struct
- Categorizes themes as either `"blog"` or `"personal"`

### 2. **Updated All Theme Implementations**
- **Blog themes**: minimal-retro, obsidian, terminal-candy → `site_type: "blog"`
- **Personal themes**: dark-minimal, musashi, slate-portfolio, typewriter → `site_type: "personal"`

### 3. **Theme Set Validation** (`blogr-cli/src/commands/theme.rs`)
- Validates theme compatibility with site type before setting
- Provides clear error messages listing compatible themes
- Offers actionable suggestions (choose compatible theme or change site type)

### 4. **Enhanced Theme List Display** (`blogr-cli/src/commands/theme.rs`)
- Groups themes by type in `blogr theme list` output
- Shows separate sections: "📝 Blog Themes" and "👤 Personal Website Themes"
- Makes theme selection more intuitive

## Before This Fix
```bash
$ blogr init --personal my-site
$ blogr theme set minimal-retro
✅ Theme set to: minimal-retro
$ blogr serve
Error: Failed to render personal index template
```
❌ Fails during build/serve with confusing template error

## After This Fix
```bash
$ blogr init --personal my-site
$ blogr theme set minimal-retro
Error: ❌ Theme 'minimal-retro' is a blog theme, but your site is configured as a personal site.

Blog themes: minimal-retro, obsidian, terminal-candy
Personal themes: dark-minimal, musashi, slate-portfolio, typewriter

💡 To use this theme, either:
1. Choose a compatible personal theme from the list above
2. Change your site type in blogr.toml: [site] site_type = "blog"
```
✅ Fails fast with clear guidance at theme-setting time

## Enhanced Theme List Output
```bash
$ blogr theme list
📋 Available themes:

📝 Blog Themes (for traditional blogs with posts):
  📦 minimal-retro - An artistic, minimal theme focused on content...
      👤 Author: Blogr Team | 📦 Version: 2.0.0
  📦 obsidian - Adopts Obsidian community themes to style...
      👤 Author: Blogr Team | 📦 Version: 1.0.0
  📦 terminal-candy - A quirky terminal-inspired theme...
      👤 Author: Blogr Team | 📦 Version: 1.0.0

👤 Personal Website Themes (for portfolios and personal sites):
  ✅ dark-minimal (active) - A dark, minimal theme...
      👤 Author: Blogr Team | 📦 Version: 1.0.0
  📦 musashi - An elegant monochrome theme...
      👤 Author: Blogr Team | 📦 Version: 1.0.0
  📦 slate-portfolio - A sleek, modern dark portfolio theme...
      👤 Author: Blogr Team | 📦 Version: 1.0.0
  📦 typewriter - A vintage typewriter-inspired theme...
      👤 Author: Blogr Team | 📦 Version: 1.0.0
```

## Testing

✅ **Test 1: Personal site with blog theme (reproducing original issue)**
```bash
$ blogr init --personal test_site
$ blogr theme set minimal-retro
# Result: Clear error with suggestions ✅
```

✅ **Test 2: Blog site with personal theme**
```bash
$ blogr init test_blog
$ blogr theme set dark-minimal
# Result: Clear error with suggestions ✅
```

✅ **Test 3: Compatible themes work correctly**
```bash
$ blogr theme set musashi  # Personal theme on personal site
$ blogr build              # Builds successfully ✅

$ blogr theme set obsidian # Blog theme on blog site
$ blogr build              # Builds successfully ✅
```

✅ **Test 4: Theme list displays categorized output**
```bash
$ blogr theme list
# Result: Themes grouped by type ✅
```

## Benefits
1. **Prevents confusing errors** - Users can't set incompatible themes
2. **Better UX** - Clear error messages explain the issue and provide solutions
3. **Fail-fast validation** - Issues caught at theme-setting time, not during build/serve
4. **Improved discoverability** - Categorized theme list helps users find compatible themes

## Breaking Changes
None. This is a backward-compatible enhancement that only adds validation.

## Checklist
- [x] Code compiles without errors
- [x] No linter warnings
- [x] All scenarios tested (personal→blog theme, blog→personal theme, compatible themes)
- [x] Error messages are clear and actionable
- [x] Documentation updated in code comments

