### PR TITLE
Refactor Config App State & Save on Enter

### DIFF
--- a/blogr-cli/src/tui/config_app.rs
+++ b/blogr-cli/src/tui/config_app.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::project::Project;
 use crate::tui::theme::TuiTheme;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -194,295 +194,17 @@ impl ConfigSection {
     }
 }
 
-/// Configuration editor mode
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConfigMode {
-    Browse,
-    Edit,
-    Help,
-}
-
-/// Configuration editor application
+/// public API of the application
 pub struct ConfigApp {
-    /// Current running state
-    pub running: bool,
-    /// Current mode
-    mode: ConfigMode,
-    /// Current configuration
-    config: Config,
-    /// Project reference
-    project: Project,
-    /// Current theme
+    state: ConfigAppState,
     theme: TuiTheme,
-    /// Current field selection
-    selected_field: ConfigField,
-    /// The index of the field in the ConfigField enum variant array
-    config_index: usize,
-    /// Lays out the ConfigField into sections with headers and blank lines.
-    /// Maps the ConfigField index into the actual list layout so ListState can render the selection.
-    list_layout: HighLevelConfigList,
-    /// List state for field selection
-    list_state: ListState,
-    /// Current edit buffer
-    edit_buffer: String,
-    /// Status message
-    status_message: String,
-    /// Whether config has been modified
-    modified: bool,
-    /// Show help overlay
-    show_help: bool,
 }
 
 impl ConfigApp {
-    /// Create a new configuration app
     pub fn new(config: Config, project: Project, theme: TuiTheme) -> Self {
-        let mut list_state = ListState::default();
-        let list_layout = HighLevelConfigList::new();
-        let selected_field = ConfigField::BlogTitle;
-        list_state.select(list_layout.index_of(&selected_field));
-        Self {
-            running: true,
-            mode: ConfigMode::Browse,
-            config,
-            project,
-            theme,
-            selected_field,
-            config_index: 0, // must match the index of selected_field in ConfigField::VARIANTS
-            list_layout,
-            list_state,
-            edit_buffer: String::new(),
-            status_message: "Navigate with ↑/↓, Enter to edit, 'q' to quit, 's' to save"
-                .to_string(),
-            modified: false,
-            show_help: false,
-        }
+        let state = ConfigAppState::new(config, project);
+        Self { state, theme }
     }
-
-    /// Handle key events
-    pub fn handle_key_event(&mut self, key: KeyEvent) -> AppResult<()> {
-        match self.mode {
-            ConfigMode::Browse => self.handle_browse_mode(key),
-            ConfigMode::Edit => self.handle_edit_mode(key),
-            ConfigMode::Help => self.handle_help_mode(key),
-        }
-    }
-
-    fn handle_browse_mode(&mut self, key: KeyEvent) -> AppResult<()> {
-        match key.code {
-            KeyCode::Char('q') => {
-                if self.modified {
-                    self.status_message =
-                        "Configuration modified! Press 's' to save or 'Q' to quit without saving"
-                            .to_string();
-                } else {
-                    self.running = false;
-                }
-            }
-            KeyCode::Char('Q') => {
-                self.running = false;
-            }
-            KeyCode::Char('s') => {
-                self.save_config()?;
-            }
-            KeyCode::Char('h') | KeyCode::F(1) => {
-                self.show_help = true;
-                self.mode = ConfigMode::Help;
-            }
-            KeyCode::Up => {
-                if self.config_index == 0 {
-                    return Ok(());
-                }
-                let prev = ConfigField::VARIANTS.get(self.config_index - 1);
-                if let Some(prev) = prev {
-                    self.selected_field = *prev;
-                    self.config_index -= 1;
-                    self.list_state.select(self.list_layout.index_of(prev));
-                }
-            }
-            KeyCode::Down => {
-                let next = ConfigField::VARIANTS.get(self.config_index + 1);
-                if let Some(next) = next {
-                    self.selected_field = *next;
-                    self.config_index += 1;
-                    self.list_state.select(self.list_layout.index_of(next));
-                }
-            }
-            KeyCode::Enter => {
-                self.enter_edit_mode();
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn handle_edit_mode(&mut self, key: KeyEvent) -> AppResult<()> {
-        match key.code {
-            KeyCode::Esc => {
-                self.mode = ConfigMode::Browse;
-                self.edit_buffer.clear();
-                self.status_message = "Edit cancelled".to_string();
-            }
-            KeyCode::Enter => {
-                self.apply_edit()?;
-            }
-            KeyCode::Backspace => {
-                self.edit_buffer.pop();
-            }
-            KeyCode::Char(c) => {
-                if key.modifiers.contains(KeyModifiers::CONTROL) {
-                    if c == 'c' {
-                        self.mode = ConfigMode::Browse;
-                        self.edit_buffer.clear();
-                        self.status_message = "Edit cancelled".to_string();
-                    }
-                } else {
-                    self.edit_buffer.push(c);
-                }
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn handle_help_mode(&mut self, key: KeyEvent) -> AppResult<()> {
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('h') | KeyCode::F(1) => {
-                self.show_help = false;
-                self.mode = ConfigMode::Browse;
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn enter_edit_mode(&mut self) {
-        self.edit_buffer = self.selected_field.get_value(&self.config);
-        self.mode = ConfigMode::Edit;
-        self.status_message = format!(
-            "Editing {}: Press Enter to save, Esc to cancel",
-            self.selected_field
-        );
-    }
-
-    fn apply_edit(&mut self) -> AppResult<()> {
-        let value = self.edit_buffer.trim().to_string();
-
-        // Apply the change to the configuration
-        match self.selected_field {
-            ConfigField::BlogTitle => {
-                if !value.is_empty() {
-                    self.config.blog.title = value;
-                    self.modified = true;
-                }
-            }
-            ConfigField::BlogAuthor => {
-                if !value.is_empty() {
-                    self.config.blog.author = value;
-                    self.modified = true;
-                }
-            }
-            ConfigField::BlogDescription => {
-                if !value.is_empty() {
-                    self.config.blog.description = value;
-                    self.modified = true;
-                }
-            }
-            ConfigField::BlogBaseUrl => {
-                if !value.is_empty() {
-                    self.config.blog.base_url = value;
-                    self.modified = true;
-                }
-            }
-            ConfigField::BlogLanguage => {
-                self.config.blog.language = if value.is_empty() { None } else { Some(value) };
-                self.modified = true;
-            }
-            ConfigField::BlogTimezone => {
-                self.config.blog.timezone = if value.is_empty() { None } else { Some(value) };
-                self.modified = true;
-            }
-            ConfigField::ThemeName => {
-                if !value.is_empty() {
-                    self.config.theme.name = value;
-                    self.modified = true;
-                }
-            }
-            ConfigField::DomainPrimary => {
-                if self.config.blog.domains.is_none() {
-                    self.config.blog.domains = Some(crate::config::DomainConfig {
-                        primary: None,
-                        aliases: Vec::new(),
-                        subdomain: None,
-                        enforce_https: true,
-                        github_pages_domain: None,
-                    });
-                }
-                if let Some(domains) = &mut self.config.blog.domains {
-                    domains.primary = if value.is_empty() {
-                        None
-                    } else {
-                        Some(value.clone())
-                    };
-                    domains.github_pages_domain = if value.is_empty() { None } else { Some(value) };
-                    self.modified = true;
-                }
-            }
-            ConfigField::DomainEnforceHttps => {
-                let enforce_https = value.to_lowercase() == "true";
-                if self.config.blog.domains.is_none() {
-                    self.config.blog.domains = Some(crate::config::DomainConfig {
-                        primary: None,
-                        aliases: Vec::new(),
-                        subdomain: None,
-                        enforce_https,
-                        github_pages_domain: None,
-                    });
-                }
-                if let Some(domains) = &mut self.config.blog.domains {
-                    domains.enforce_https = enforce_https;
-                    self.modified = true;
-                }
-            }
-            ConfigField::BuildOutputDir => {
-                self.config.build.output_dir = if value.is_empty() { None } else { Some(value) };
-                self.modified = true;
-            }
-            ConfigField::BuildDrafts => {
-                self.config.build.drafts = value.to_lowercase() == "true";
-                self.modified = true;
-            }
-            ConfigField::BuildFuturePosts => {
-                self.config.build.future_posts = value.to_lowercase() == "true";
-                self.modified = true;
-            }
-            ConfigField::DevPort => {
-                if let Ok(port) = value.parse::<u16>() {
-                    if port > 0 {
-                        self.config.dev.port = port;
-                        self.modified = true;
-                    }
-                }
-            }
-            ConfigField::DevAutoReload => {
-                self.config.dev.auto_reload = value.to_lowercase() == "true";
-                self.modified = true;
-            }
-        }
-
-        self.mode = ConfigMode::Browse;
-        self.edit_buffer.clear();
-        self.status_message = format!("{} updated", self.selected_field);
-        Ok(())
-    }
-
-    fn save_config(&mut self) -> AppResult<()> {
-        let config_path = self.project.root.join("blogr.toml");
-        self.config.save_to_file(&config_path)?;
-        self.modified = false;
-        self.status_message = "Configuration saved successfully!".to_string();
-        Ok(())
-    }
-
     /// Render the application
     pub fn render(&mut self, frame: &mut Frame) {
         let chunks = Layout::default()
@@ -494,57 +216,199 @@ impl ConfigApp {
             ])
             .split(frame.size());
 
-        self.render_header(frame, chunks[0]);
-        self.render_main_content(frame, chunks[1]);
-        self.render_status_bar(frame, chunks[2]);
+        self.state.render_header(frame, chunks[0], &self.theme);
+        self.state
+            .render_main_content(frame, chunks[1], &self.theme);
+        self.state.render_status_bar(frame, chunks[2], &self.theme);
+    }
 
-        if self.show_help {
-            self.render_help_overlay(frame);
+    pub fn handle_key_event(mut self, key: KeyEvent) -> AppResult<Self> {
+        self.state = self.state.handle_key_event(key)?;
+        Ok(self)
+    }
+
+    /// Handle tick event
+    pub fn tick(&self) {}
+
+    pub fn is_stopped(&self) -> bool {
+        matches!(self.state, ConfigAppState::Shutdown(_))
+    }
+}
+
+/// Configuration editor mode.
+/// The larger variants are boxed at Clippy's suggestion.
+enum ConfigAppState {
+    Browse(Box<Browse>),
+    Edit(Box<Edit>),
+    Help(Box<Help>),
+    Shutdown(Shutdown),
+}
+
+impl ConfigAppState {
+    pub fn new(config: Config, project: Project) -> Self {
+        Self::Browse(Box::new(Browse::new(config, project)))
+    }
+
+    fn render_main_content(&mut self, frame: &mut Frame, area: Rect, theme: &TuiTheme) {
+        match self {
+            Self::Browse(app) => app.render_browse_mode(frame, area, theme),
+            Self::Edit(app) => app.render_edit_mode(frame, area, theme),
+            Self::Help(app) => app.render_help_overlay(frame, theme), // Help is rendered as overlay
+            Self::Shutdown(_) => {}
         }
     }
 
-    fn render_header(&self, frame: &mut Frame, area: Rect) {
-        let title = if self.modified {
-            "Blogr Configuration Editor *"
-        } else {
-            "Blogr Configuration Editor"
-        };
+    fn render_header(&self, frame: &mut Frame, area: Rect, theme: &TuiTheme) {
+        let title = "Blogr Configuration Editor";
 
         let header = Paragraph::new(title)
             .block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .border_style(self.theme.border_style())
+                    .border_style(theme.border_style())
                     .title("Configuration")
-                    .title_style(self.theme.title_style()),
+                    .title_style(theme.title_style()),
             )
-            .style(self.theme.text_style());
+            .style(theme.text_style());
 
         frame.render_widget(header, area);
     }
 
-    fn render_main_content(&mut self, frame: &mut Frame, area: Rect) {
-        match self.mode {
-            ConfigMode::Browse => self.render_browse_mode(frame, area),
-            ConfigMode::Edit => self.render_edit_mode(frame, area),
-            ConfigMode::Help => {} // Help is rendered as overlay
+    fn render_status_bar(&self, frame: &mut Frame, area: Rect, theme: &TuiTheme) {
+        let status = Paragraph::new(self.get_status())
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(theme.border_style()),
+            )
+            .style(theme.text_style());
+
+        frame.render_widget(status, area);
+    }
+
+    fn handle_key_event(self, key: KeyEvent) -> AppResult<Self> {
+        match self {
+            Self::Browse(app) => Ok(app.handle_key_event(key)),
+            Self::Edit(app) => app.handle_key_event(key),
+            Self::Help(app) => Ok(app.handle_key_event(key)),
+            Self::Shutdown(app) => Ok(app.into()),
         }
     }
 
-    fn render_browse_mode(&mut self, frame: &mut Frame, area: Rect) {
+    fn get_status(&self) -> String {
+        match self {
+            Self::Browse(app) => app.status_message.clone(),
+            Self::Edit(app) => app.browse_data.status_message.clone(),
+            Self::Help(app) => app.browse_data.status_message.clone(),
+            Self::Shutdown(_) => "Shutting down".to_string(),
+        }
+    }
+}
+
+impl From<Browse> for ConfigAppState {
+    fn from(value: Browse) -> Self {
+        ConfigAppState::Browse(Box::new(value))
+    }
+}
+
+impl From<Edit> for ConfigAppState {
+    fn from(value: Edit) -> Self {
+        ConfigAppState::Edit(Box::new(value))
+    }
+}
+
+impl From<Help> for ConfigAppState {
+    fn from(value: Help) -> Self {
+        ConfigAppState::Help(Box::new(value))
+    }
+}
+
+impl From<Shutdown> for ConfigAppState {
+    fn from(value: Shutdown) -> Self {
+        ConfigAppState::Shutdown(value)
+    }
+}
+
+struct Browse {
+    config: Config,
+    project: Project,
+    /// Current field selection
+    selected_field: ConfigField,
+    /// The index of the field in the ConfigField enum variant array
+    config_index: usize,
+    /// Lays out the ConfigField into sections with headers and blank lines.
+    /// Maps the ConfigField index into the actual list layout so ListState can render the selection.
+    list_layout: HighLevelConfigList,
+    /// List state for field selection
+    list_state: ListState,
+    status_message: String,
+}
+
+impl Browse {
+    fn new(config: Config, project: Project) -> Self {
+        let mut list_state = ListState::default();
+        let list_layout = HighLevelConfigList::new();
+        let selected_field = ConfigField::BlogTitle;
+        list_state.select(list_layout.index_of(&selected_field));
+        Self {
+            config,
+            project,
+            selected_field,
+            config_index: 0, // must match the index of selected_field in ConfigField::VARIANTS
+            list_layout,
+            list_state,
+            status_message: "Navigate with ↑/↓, Enter to edit, 'q' to quit".to_string(),
+        }
+    }
+
+    pub fn handle_key_event(self, key: KeyEvent) -> ConfigAppState {
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Char('Q') => self.enter_shutdown_mode().into(),
+            KeyCode::Char('h') | KeyCode::F(1) => self.enter_help_mode().into(),
+            KeyCode::Up => self.key_up().into(),
+            KeyCode::Down => self.key_down().into(),
+            KeyCode::Enter => self.enter_edit_mode().into(),
+            _ => self.into(),
+        }
+    }
+
+    fn key_up(mut self) -> Self {
+        if self.config_index == 0 {
+            return self;
+        }
+        let prev = ConfigField::VARIANTS.get(self.config_index - 1);
+        if let Some(prev) = prev {
+            self.selected_field = *prev;
+            self.config_index -= 1;
+            self.list_state.select(self.list_layout.index_of(prev));
+        }
+        self
+    }
+
+    fn key_down(mut self) -> Self {
+        let next = ConfigField::VARIANTS.get(self.config_index + 1);
+        if let Some(next) = next {
+            self.selected_field = *next;
+            self.config_index += 1;
+            self.list_state.select(self.list_layout.index_of(next));
+        }
+        self
+    }
+
+    fn render_browse_mode(&mut self, frame: &mut Frame, area: Rect, theme: &TuiTheme) {
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(area);
 
         // Render field list
-        self.render_field_list(frame, chunks[0]);
+        self.render_field_list(frame, chunks[0], theme);
 
         // Render field details
-        self.render_field_details(frame, chunks[1]);
+        self.render_field_details(frame, chunks[1], theme);
     }
 
-    fn render_field_list(&mut self, frame: &mut Frame, area: Rect) {
+    fn render_field_list(&mut self, frame: &mut Frame, area: Rect, theme: &TuiTheme) {
         let items = self
             .list_layout
             .0
@@ -561,16 +425,16 @@ impl ConfigApp {
                     ListItem::new(Line::from(vec![
                         Span::styled(
                             format!("  {}: ", field),
-                            Style::default().fg(self.theme.text_color),
+                            Style::default().fg(theme.text_color),
                         ),
-                        Span::styled(display_value, Style::default().fg(self.theme.text_color)),
+                        Span::styled(display_value, Style::default().fg(theme.text_color)),
                     ]))
                 }
                 HighLevelListItem::Section(section) => ListItem::new(Line::from(Span::styled(
                     section.to_string(),
                     Style::default()
                         .add_modifier(Modifier::BOLD)
-                        .fg(self.theme.primary_color),
+                        .fg(theme.primary_color),
                 ))),
             })
             .collect::<Vec<ListItem>>();
@@ -580,18 +444,18 @@ impl ConfigApp {
                 Block::default()
                     .borders(Borders::ALL)
                     .title("Configuration Fields")
-                    .border_style(self.theme.focused_border_style()),
+                    .border_style(theme.focused_border_style()),
             )
             .highlight_style(
                 Style::default()
-                    .bg(self.theme.primary_color)
+                    .bg(theme.primary_color)
                     .add_modifier(Modifier::BOLD),
             );
 
         frame.render_stateful_widget(list, area, &mut self.list_state);
     }
 
-    fn render_field_details(&self, frame: &mut Frame, area: Rect) {
+    fn render_field_details(&self, frame: &mut Frame, area: Rect, theme: &TuiTheme) {
         let value = self.selected_field.get_value(&self.config);
         let effective_url = if matches!(self.selected_field, ConfigField::BlogBaseUrl) {
             format!("\nEffective URL: {}", self.config.get_effective_base_url())
@@ -612,23 +476,81 @@ impl ConfigApp {
                 Block::default()
                     .borders(Borders::ALL)
                     .title("Field Details")
-                    .border_style(self.theme.border_style()),
+                    .border_style(theme.border_style()),
             )
             .wrap(Wrap { trim: true })
-            .style(self.theme.text_style());
+            .style(theme.text_style());
 
         frame.render_widget(details, area);
     }
 
-    fn render_edit_mode(&self, frame: &mut Frame, area: Rect) {
+    fn enter_edit_mode(mut self) -> Edit {
+        let edit_buffer = self.selected_field.get_value(&self.config);
+        self.status_message = format!(
+            "Editing {}: Press Enter to save, Esc to cancel",
+            self.selected_field
+        );
+        Edit {
+            new_config: self.config.clone(),
+            browse_data: self,
+            edit_buffer,
+        }
+    }
+
+    fn enter_help_mode(self) -> Help {
+        Help { browse_data: self }
+    }
+
+    fn enter_shutdown_mode(self) -> Shutdown {
+        Shutdown
+    }
+}
+
+struct Edit {
+    browse_data: Browse,
+    edit_buffer: String,
+    new_config: Config,
+}
+
+struct Help {
+    browse_data: Browse,
+}
+
+struct Shutdown;
+
+impl Edit {
+    pub fn handle_key_event(mut self, key: KeyEvent) -> AppResult<ConfigAppState> {
+        match key.code {
+            KeyCode::Esc => {
+                let mut browse_data = self.enter_browse_mode();
+                browse_data.status_message = "Edit cancelled".to_string();
+                Ok(browse_data.into())
+            }
+            KeyCode::Enter => {
+                let browse_data = self.apply_edit()?;
+                Ok(browse_data.into())
+            }
+            KeyCode::Backspace => {
+                self.edit_buffer.pop();
+                Ok(self.into())
+            }
+            KeyCode::Char(c) => {
+                self.edit_buffer.push(c);
+                Ok(self.into())
+            }
+            _ => Ok(self.into()),
+        }
+    }
+
+    fn render_edit_mode(&self, frame: &mut Frame, area: Rect, theme: &TuiTheme) {
         let edit_area = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(5), Constraint::Min(0)])
             .split(area);
 
-        let input_text = if self.selected_field.is_boolean() {
+        let input_text = if self.browse_data.selected_field.is_boolean() {
             format!("{} (true/false)", self.edit_buffer)
-        } else if self.selected_field.is_numeric() {
+        } else if self.browse_data.selected_field.is_numeric() {
             format!("{} (number)", self.edit_buffer)
         } else {
             self.edit_buffer.clone()
@@ -638,16 +560,16 @@ impl ConfigApp {
             .block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .title(format!("Editing: {}", self.selected_field))
-                    .border_style(self.theme.focused_border_style()),
+                    .title(format!("Editing: {}", self.browse_data.selected_field))
+                    .border_style(theme.focused_border_style()),
             )
-            .style(self.theme.text_style());
+            .style(theme.text_style());
 
         frame.render_widget(input, edit_area[0]);
 
-        let help_text = if self.selected_field.is_boolean() {
+        let help_text = if self.browse_data.selected_field.is_boolean() {
             "Enter 'true' or 'false'"
-        } else if self.selected_field.is_numeric() {
+        } else if self.browse_data.selected_field.is_numeric() {
             "Enter a valid number"
         } else {
             "Enter the new value"
@@ -661,27 +583,127 @@ impl ConfigApp {
             Block::default()
                 .borders(Borders::ALL)
                 .title("Help")
-                .border_style(self.theme.border_style()),
+                .border_style(theme.border_style()),
         )
         .wrap(Wrap { trim: true })
-        .style(self.theme.text_style());
+        .style(theme.text_style());
 
         frame.render_widget(help, edit_area[1]);
     }
 
-    fn render_status_bar(&self, frame: &mut Frame, area: Rect) {
-        let status = Paragraph::new(self.status_message.clone())
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(self.theme.border_style()),
-            )
-            .style(self.theme.text_style());
+    fn apply_edit(mut self) -> AppResult<Browse> {
+        let value = self.edit_buffer.trim().to_string();
 
-        frame.render_widget(status, area);
+        // Apply the change to the configuration
+        match self.browse_data.selected_field {
+            ConfigField::BlogTitle => {
+                if !value.is_empty() {
+                    self.new_config.blog.title = value;
+                }
+            }
+            ConfigField::BlogAuthor => {
+                if !value.is_empty() {
+                    self.new_config.blog.author = value;
+                }
+            }
+            ConfigField::BlogDescription => {
+                if !value.is_empty() {
+                    self.new_config.blog.description = value;
+                }
+            }
+            ConfigField::BlogBaseUrl => {
+                if !value.is_empty() {
+                    self.new_config.blog.base_url = value;
+                }
+            }
+            ConfigField::BlogLanguage => {
+                self.new_config.blog.language = if value.is_empty() { None } else { Some(value) };
+            }
+            ConfigField::BlogTimezone => {
+                self.new_config.blog.timezone = if value.is_empty() { None } else { Some(value) };
+            }
+            ConfigField::ThemeName => {
+                if !value.is_empty() {
+                    self.new_config.theme.name = value;
+                }
+            }
+            ConfigField::DomainPrimary => {
+                if self.new_config.blog.domains.is_none() {
+                    self.new_config.blog.domains = Some(crate::config::DomainConfig {
+                        primary: None,
+                        aliases: Vec::new(),
+                        subdomain: None,
+                        enforce_https: true,
+                        github_pages_domain: None,
+                    });
+                }
+                if let Some(domains) = &mut self.new_config.blog.domains {
+                    domains.primary = if value.is_empty() {
+                        None
+                    } else {
+                        Some(value.clone())
+                    };
+                    domains.github_pages_domain = if value.is_empty() { None } else { Some(value) };
+                }
+            }
+            ConfigField::DomainEnforceHttps => {
+                let enforce_https = value.to_lowercase() == "true";
+                if self.new_config.blog.domains.is_none() {
+                    self.new_config.blog.domains = Some(crate::config::DomainConfig {
+                        primary: None,
+                        aliases: Vec::new(),
+                        subdomain: None,
+                        enforce_https,
+                        github_pages_domain: None,
+                    });
+                }
+                if let Some(domains) = &mut self.new_config.blog.domains {
+                    domains.enforce_https = enforce_https;
+                }
+            }
+            ConfigField::BuildOutputDir => {
+                self.new_config.build.output_dir =
+                    if value.is_empty() { None } else { Some(value) };
+            }
+            ConfigField::BuildDrafts => {
+                self.new_config.build.drafts = value.to_lowercase() == "true";
+            }
+            ConfigField::BuildFuturePosts => {
+                self.new_config.build.future_posts = value.to_lowercase() == "true";
+            }
+            ConfigField::DevPort => {
+                if let Ok(port) = value.parse::<u16>() {
+                    if port > 0 {
+                        self.new_config.dev.port = port;
+                    }
+                }
+            }
+            ConfigField::DevAutoReload => {
+                self.new_config.dev.auto_reload = value.to_lowercase() == "true";
+            }
+        }
+
+        let config_path = self.browse_data.project.root.join("blogr.toml");
+        self.new_config.save_to_file(&config_path)?;
+        self.browse_data.config = self.new_config.clone();
+        self.browse_data.status_message = "Configuration saved successfully!".to_string();
+        Ok(self.enter_browse_mode())
     }
 
-    fn render_help_overlay(&self, frame: &mut Frame) {
+    fn enter_browse_mode(self) -> Browse {
+        self.browse_data
+    }
+}
+
+impl Help {
+    pub fn handle_key_event(self, key: KeyEvent) -> ConfigAppState {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('h') | KeyCode::F(1) => self.enter_browse_mode().into(),
+            _ => self.into(),
+        }
+    }
+
+    fn render_help_overlay(&self, frame: &mut Frame, theme: &TuiTheme) {
         let area = frame.size();
         let popup_area = Layout::default()
             .direction(Direction::Vertical)
@@ -713,8 +735,7 @@ impl ConfigApp {
             "",
             "Actions:",
             "  s         - Save configuration",
-            "  q         - Quit (with save prompt)",
-            "  Q         - Quit without saving",
+            "  q         - Quit",
             "  h/F1      - Toggle this help",
             "",
             "Field Types:",
@@ -730,14 +751,15 @@ impl ConfigApp {
                 Block::default()
                     .borders(Borders::ALL)
                     .title("Help")
-                    .border_style(self.theme.focused_border_style()),
+                    .border_style(theme.focused_border_style()),
             )
             .wrap(Wrap { trim: true })
-            .style(self.theme.text_style());
+            .style(theme.text_style());
 
         frame.render_widget(help, popup_area);
     }
 
-    /// Handle tick event
-    pub fn tick(&self) {}
+    fn enter_browse_mode(self) -> Browse {
+        self.browse_data
+    }
 }

--- a/blogr-cli/src/tui/mod.rs
+++ b/blogr-cli/src/tui/mod.rs
@@ -20,6 +20,8 @@ use ratatui::{
 };
 use std::io;
 
+use crate::tui::config_app::ConfigApp;
+
 /// Representation of a terminal user interface.
 ///
 /// It is responsible for setting up the terminal,
@@ -67,10 +69,7 @@ impl<B: Backend> Tui<B> {
     }
 
     /// Draw the configuration app
-    pub fn draw_config(
-        &mut self,
-        config_app: &mut crate::tui::config_app::ConfigApp,
-    ) -> AppResult<()> {
+    pub fn draw_config(&mut self, config_app: &mut ConfigApp) -> AppResult<()> {
         self.terminal.draw(|frame| config_app.render(frame))?;
         Ok(())
     }

--- a/blogr-cli/src/tui_launcher.rs
+++ b/blogr-cli/src/tui_launcher.rs
@@ -1,5 +1,6 @@
 use crate::content::{Post, PostManager};
 use crate::project::Project;
+use crate::tui::config_app::ConfigApp;
 use crate::tui::theme::TuiTheme;
 use crate::tui::{self, App, Event};
 use anyhow::Result;
@@ -101,7 +102,7 @@ pub async fn launch_config_editor(project: &Project) -> Result<()> {
     tui.init()?;
 
     // Create configuration app
-    let mut config_app = crate::tui::config_app::ConfigApp::new(config, project.clone(), tui_theme);
+    let mut config_app = ConfigApp::new(config, project.clone(), tui_theme);
 
     // Main event loop
     let result = loop {
@@ -114,7 +115,7 @@ pub async fn launch_config_editor(project: &Project) -> Result<()> {
                 config_app.tick();
             }
             Event::Key(key_event) => {
-                config_app.handle_key_event(key_event)?;
+                config_app = config_app.handle_key_event(key_event)?;
             }
             Event::Mouse(_) => {}
             Event::Resize(_, _) => {}
@@ -122,7 +123,7 @@ pub async fn launch_config_editor(project: &Project) -> Result<()> {
         }
 
         // Check if we should quit
-        if !config_app.running {
+        if config_app.is_stopped() {
             break Ok(());
         }
     };


### PR DESCRIPTION
__PROBLEM__
To address #31 we need to be able to add edit modes to the config app tui other than text, such as enum selection. This PR lays the groundwork for that by refactoring the state management, splitting the monolithic `ConfigApp` into specialized structs for each app mode - `Browse`, `Edit`, `Help`, and `Shutdown`. It's now easier to add new modes without affecting existing app logic.

__IMPLEMENTATION__
Currently we use a `ConfigApp` struct that contains an enum that tells it what state the app is in. The enum doesn't contain any additional information, and all app info is available to any app state at any time.

We expand on that system with this PR. Each enum variant contains a struct with data that is pertinent to that state. Transitions between states are controlled by the type system. The render behavior is different for each state, so it's now defined in methods that are associated with those state types.

__SAVE ON ENTER__
Hitting enter when in edit mode not only takes you to Browse mode, but immediately updates blogr.toml with your changes. We don't have to manage an unsaved browse state, so fields like `modified` have been deprecated.


https://github.com/user-attachments/assets/a8ed9149-3c0a-4108-b9d7-9763e482eb6c


