### PR TITLE
fix(themes): normalize theme name lookup to handle all naming variants

### DIFF
--- a/blogr-cli/src/commands/config.rs
+++ b/blogr-cli/src/commands/config.rs
@@ -360,7 +360,11 @@ pub async fn handle_set(key: String, value: String) -> Result<()> {
         ["blog", "base_url"] => config.blog.base_url = value.clone(),
         ["blog", "language"] => config.blog.language = Some(value.clone()),
         ["blog", "timezone"] => config.blog.timezone = Some(value.clone()),
-        ["theme", "name"] => config.theme.name = value.clone(),
+        ["theme", "name"] => {
+            let theme = blogr_themes::get_theme(&value)
+                .ok_or_else(|| anyhow::anyhow!("Theme '{}' not found", value))?;
+            config.theme.name = theme.info().slug();
+        }
         _ => {
             anyhow::bail!("Unknown or unsupported configuration key: {}", key);
         }

--- a/blogr-cli/src/commands/project.rs
+++ b/blogr-cli/src/commands/project.rs
@@ -104,9 +104,7 @@ pub async fn handle_check() -> Result<()> {
     // Check theme availability
     let config = project.load_config()?;
     let theme_name = &config.theme.name;
-    // For now, we'll assume minimal-retro is always available
-    // In the future, this could check against available themes
-    if theme_name != "minimal-retro" {
+    if blogr_themes::get_theme(theme_name).is_none() {
         Console::warn(&format!("Theme '{}' may not be available", theme_name));
     }
 

--- a/blogr-cli/src/commands/theme.rs
+++ b/blogr-cli/src/commands/theme.rs
@@ -102,7 +102,9 @@ pub async fn handle_info(name: String) -> Result<()> {
         // Check if theme is currently active
         if let Ok(Some(project)) = Project::find_project() {
             if let Ok(config) = project.load_config() {
-                if config.theme.name == name {
+                if blogr_themes::normalize_theme_name(&config.theme.name)
+                    == blogr_themes::normalize_theme_name(&name)
+                {
                     println!();
                     println!("✅ This theme is currently active");
                 } else {
@@ -176,8 +178,8 @@ pub async fn handle_set(name: String) -> Result<()> {
         ));
     }
 
-    // Update theme name
-    config.theme.name = name.clone();
+    // Update theme name (use canonical slug form for config)
+    config.theme.name = theme.info().slug();
 
     // Load theme configuration schema and update config with defaults
     let theme_info = theme.info();

--- a/blogr-cli/src/commands/theme.rs
+++ b/blogr-cli/src/commands/theme.rs
@@ -80,6 +80,7 @@ pub async fn handle_info(name: String) -> Result<()> {
     // Load theme by name
     if let Some(theme) = get_theme(&name) {
         let info = theme.info();
+        let slug = info.slug();
 
         println!("🎨 Theme: {}", info.name);
         println!("📝 Description: {}", info.description);
@@ -102,9 +103,7 @@ pub async fn handle_info(name: String) -> Result<()> {
         // Check if theme is currently active
         if let Ok(Some(project)) = Project::find_project() {
             if let Ok(config) = project.load_config() {
-                if blogr_themes::normalize_theme_name(&config.theme.name)
-                    == blogr_themes::normalize_theme_name(&name)
-                {
+                if config.theme.name == slug {
                     println!();
                     println!("✅ This theme is currently active");
                 } else {

--- a/blogr-cli/src/generator/site.rs
+++ b/blogr-cli/src/generator/site.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::content::{Post, PostManager, PostStatus};
 use crate::project::Project;
 use anyhow::{anyhow, Result};
-use blogr_themes::{get_theme_by_name, SiteType, Theme};
+use blogr_themes::{get_theme, SiteType, Theme};
 use chrono::{Datelike, Utc};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -179,8 +179,8 @@ Thank you!`);
     ) -> Result<Self> {
         // Get theme
         let theme_name = &config.theme.name;
-        let theme = get_theme_by_name(theme_name)
-            .ok_or_else(|| anyhow!("Theme '{}' not found", theme_name))?;
+        let theme =
+            get_theme(theme_name).ok_or_else(|| anyhow!("Theme '{}' not found", theme_name))?;
 
         // Set up template engine (create empty Tera instance)
         let mut tera = Tera::default();
@@ -233,7 +233,7 @@ Thank you!`);
 
     /// Build the entire site
     pub fn build(&self) -> Result<()> {
-        let theme_info = get_theme_by_name(&self.config.theme.name)
+        let theme_info = get_theme(&self.config.theme.name)
             .ok_or(anyhow!(
                 "Theme {} not found in this version of Blogr.",
                 self.config.theme.name

--- a/blogr-cli/src/newsletter/api.rs
+++ b/blogr-cli/src/newsletter/api.rs
@@ -1924,9 +1924,9 @@ mod tests {
 
     #[test]
     fn test_compose_newsletter_theme_not_found() {
-        // Default config has "minimal-retro" which doesn't match any theme
         let temp_dir = tempdir().unwrap();
-        let config = Config::default();
+        let mut config = Config::default();
+        config.theme.name = "nonexistent-theme".to_string();
         let newsletter_manager = NewsletterManager::new(config.clone(), temp_dir.path()).unwrap();
         let state = ApiState {
             newsletter_manager: Arc::new(newsletter_manager),

--- a/blogr-cli/src/project.rs
+++ b/blogr-cli/src/project.rs
@@ -233,9 +233,12 @@ impl Project {
             .with_context(|| "Failed to create README.md file")?;
 
         // Create content.md for personal info - theme-specific
-        let content_md = match config.theme.name.as_str() {
-            "musashi" => blogr_themes::MusashiTheme::example_content(&config.blog.author),
-            "dark-minimal" => blogr_themes::DarkMinimalTheme::example_content(&config.blog.author),
+        let resolved_slug = blogr_themes::get_theme(&config.theme.name).map(|t| t.info().slug());
+        let content_md = match resolved_slug.as_deref() {
+            Some("musashi") => blogr_themes::MusashiTheme::example_content(&config.blog.author),
+            Some("dark-minimal") => {
+                blogr_themes::DarkMinimalTheme::example_content(&config.blog.author)
+            }
             _ => {
                 // Generic fallback for other themes
                 format!(

--- a/blogr-cli/src/tui/config_app.rs
+++ b/blogr-cli/src/tui/config_app.rs
@@ -863,10 +863,9 @@ impl From<Browse> for EditTheme {
             .map(|theme| theme.info())
             .collect::<Vec<ThemeInfo>>();
 
-        let current_theme_index = options.iter().position(|theme| {
-            blogr_themes::normalize_theme_name(&theme.name)
-                == blogr_themes::normalize_theme_name(&value.config.theme.name)
-        });
+        let current_theme_index = options
+            .iter()
+            .position(|theme| theme.slug() == value.config.theme.name);
 
         let row_index = current_theme_index.unwrap_or(0);
         let mut table_state = TableState::default();

--- a/blogr-cli/src/tui/config_app.rs
+++ b/blogr-cli/src/tui/config_app.rs
@@ -863,9 +863,10 @@ impl From<Browse> for EditTheme {
             .map(|theme| theme.info())
             .collect::<Vec<ThemeInfo>>();
 
-        let current_theme_index = options
-            .iter()
-            .position(|theme| theme.name == value.config.theme.name);
+        let current_theme_index = options.iter().position(|theme| {
+            blogr_themes::normalize_theme_name(&theme.name)
+                == blogr_themes::normalize_theme_name(&value.config.theme.name)
+        });
 
         let row_index = current_theme_index.unwrap_or(0);
         let mut table_state = TableState::default();
@@ -983,12 +984,13 @@ impl EditTheme {
             .get(self.row_index)
             .expect("Index out of bounds")
             .clone();
+        let theme_slug = theme.slug();
         let default_theme_config = theme
             .config_schema
             .into_iter()
             .map(|(field_name, config)| (field_name, config.value))
             .collect::<HashMap<String, toml::Value>>();
-        self.new_config.set_theme(theme.name, default_theme_config);
+        self.new_config.set_theme(theme_slug, default_theme_config);
         //save
         self.browse_data = save_and_refresh(self.browse_data, self.new_config.clone())?;
         Ok(self.enter_browse_mode())

--- a/blogr-themes/src/lib.rs
+++ b/blogr-themes/src/lib.rs
@@ -62,7 +62,7 @@ impl ThemeInfo {
     /// Canonical slug for use in config files: lowercase, hyphen-separated.
     #[must_use]
     pub fn slug(&self) -> String {
-        self.name.to_lowercase().replace(' ', "-")
+        normalize_theme_name(&self.name).replace(' ', "-")
     }
 }
 
@@ -135,6 +135,7 @@ pub fn get_theme(name: &str) -> Option<Box<dyn Theme>> {
         .find(|theme| normalize_theme_name(&theme.info().name) == needle)
 }
 
+#[deprecated(since = "0.5.1", note = "Use `get_theme` instead")]
 #[must_use]
 pub fn get_theme_by_name(name: &str) -> Option<Box<dyn Theme>> {
     get_theme(name)
@@ -251,6 +252,18 @@ mod test {
 
         // Nonexistent theme returns None
         assert!(get_theme("nonexistent").is_none());
+    }
+
+    #[test]
+    fn slug_round_trips_through_get_theme() {
+        for theme in get_all_themes() {
+            let slug = theme.info().slug();
+            assert!(
+                get_theme(&slug).is_some(),
+                "get_theme failed to resolve slug '{}'",
+                slug
+            );
+        }
     }
 
     #[test]

--- a/blogr-themes/src/lib.rs
+++ b/blogr-themes/src/lib.rs
@@ -58,6 +58,12 @@ impl ThemeInfo {
             self.description.clone(),
         ]
     }
+
+    /// Canonical slug for use in config files: lowercase, hyphen-separated.
+    #[must_use]
+    pub fn slug(&self) -> String {
+        self.name.to_lowercase().replace(' ', "-")
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,11 +120,19 @@ pub fn get_all_themes() -> Vec<Box<dyn Theme>> {
     ]
 }
 
+/// Normalize a theme name for comparison by lowercasing and replacing hyphens/underscores with spaces.
+/// This allows `"minimal-retro"`, `"Minimal Retro"`, and `"minimal_retro"` to all match.
+#[must_use]
+pub fn normalize_theme_name(name: &str) -> String {
+    name.to_lowercase().replace(['-', '_'], " ")
+}
+
 #[must_use]
 pub fn get_theme(name: &str) -> Option<Box<dyn Theme>> {
+    let needle = normalize_theme_name(name);
     get_all_themes()
         .into_iter()
-        .find(|theme| theme.info().name.to_lowercase() == name.to_lowercase())
+        .find(|theme| normalize_theme_name(&theme.info().name) == needle)
 }
 
 #[must_use]
@@ -132,7 +146,7 @@ mod test {
     use crate::ThemeTemplates;
     use std::collections::{HashMap, HashSet};
 
-    use crate::get_all_themes;
+    use crate::{get_all_themes, get_theme};
 
     #[test]
     fn themes_have_unique_names() {
@@ -214,5 +228,38 @@ mod test {
                 )
             }
         });
+    }
+
+    #[test]
+    fn get_theme_resolves_all_name_variants() {
+        // Hyphenated slug (as stored in config)
+        assert!(get_theme("minimal-retro").is_some());
+        assert!(get_theme("dark-minimal").is_some());
+
+        // Title case display name (as returned by info())
+        assert!(get_theme("Minimal Retro").is_some());
+        assert!(get_theme("Dark Minimal").is_some());
+
+        // Underscored (module directory style)
+        assert!(get_theme("minimal_retro").is_some());
+        assert!(get_theme("dark_minimal").is_some());
+
+        // Single-word themes still work
+        assert!(get_theme("musashi").is_some());
+        assert!(get_theme("Musashi").is_some());
+        assert!(get_theme("obsidian").is_some());
+
+        // Nonexistent theme returns None
+        assert!(get_theme("nonexistent").is_none());
+    }
+
+    #[test]
+    fn theme_info_slug_matches_hyphenated_convention() {
+        for theme in get_all_themes() {
+            let slug = theme.info().slug();
+            assert_eq!(slug, slug.to_lowercase(), "slug should be lowercase");
+            assert!(!slug.contains(' '), "slug should not contain spaces");
+            assert!(!slug.contains('_'), "slug should not contain underscores");
+        }
     }
 }

--- a/blogr-themes/src/lib.rs
+++ b/blogr-themes/src/lib.rs
@@ -123,7 +123,7 @@ pub fn get_all_themes() -> Vec<Box<dyn Theme>> {
 /// Normalize a theme name for comparison by lowercasing and replacing hyphens/underscores with spaces.
 /// This allows `"minimal-retro"`, `"Minimal Retro"`, and `"minimal_retro"` to all match.
 #[must_use]
-pub fn normalize_theme_name(name: &str) -> String {
+fn normalize_theme_name(name: &str) -> String {
     name.to_lowercase().replace(['-', '_'], " ")
 }
 
@@ -133,12 +133,6 @@ pub fn get_theme(name: &str) -> Option<Box<dyn Theme>> {
     get_all_themes()
         .into_iter()
         .find(|theme| normalize_theme_name(&theme.info().name) == needle)
-}
-
-#[deprecated(since = "0.5.1", note = "Use `get_theme` instead")]
-#[must_use]
-pub fn get_theme_by_name(name: &str) -> Option<Box<dyn Theme>> {
-    get_theme(name)
 }
 
 #[cfg(test)]
@@ -229,6 +223,21 @@ mod test {
                 )
             }
         });
+    }
+
+    #[test]
+    fn themes_have_unique_slugs() {
+        let slugs: Vec<String> = get_all_themes()
+            .iter()
+            .map(|theme| theme.info().slug())
+            .collect();
+        let unique: HashSet<&String> = slugs.iter().collect();
+        assert_eq!(
+            unique.len(),
+            slugs.len(),
+            "Duplicate slugs found: {:?}",
+            slugs
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #104 — `blogr init` followed by `blogr serve` fails with "Theme 'minimal-retro' not found" because the config stores `"minimal-retro"` but the theme registers as `"Minimal Retro"`.

- Add `normalize_theme_name()` in `blogr-themes` that lowercases and replaces hyphens/underscores with spaces, so `"minimal-retro"`, `"Minimal Retro"`, and `"minimal_retro"` all resolve correctly
- Add `ThemeInfo::slug()` for canonical config-file form (lowercase, hyphenated)
- Fix all write paths (theme set, config set, TUI) to store the slug
- Fix all comparison paths to use normalization
- Fix newsletter test that relied on the broken lookup behavior

## Test plan

- [x] `cargo test --workspace` — all 134 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Manual: `blogr init test-blog && cd test-blog && blogr serve` should work without error